### PR TITLE
Return 409 Conflict for duplicate user signup and map to inline frontend errors

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -13,6 +14,7 @@ from app.api.deps import (
 from app.core.config import settings
 from app.core.security import get_password_hash, verify_password
 from app.models import (
+    APIError,
     Item,
     Message,
     UpdatePassword,
@@ -49,7 +51,10 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
+    "/",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=UserPublic,
+    responses={409: {"model": APIError, "description": "Conflict"}},
 )
 def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
@@ -57,9 +62,9 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system.",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email", "message": "Already in use"},
         )
 
     user = crud.create_user(session=session, user_create=user_in)
@@ -139,16 +144,20 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
     return Message(message="User deleted successfully")
 
 
-@router.post("/signup", response_model=UserPublic)
+@router.post(
+    "/signup",
+    response_model=UserPublic,
+    responses={409: {"model": APIError, "description": "Conflict"}},
+)
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     Create new user without the need to be logged in.
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email", "message": "Already in use"},
         )
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -97,6 +97,13 @@ class Message(SQLModel):
     message: str
 
 
+# Standard API error (documented in OpenAPI)
+class APIError(SQLModel):
+    error: str  # e.g. "conflict"
+    field: str | None = None  # e.g. "email"
+    message: str  # e.g. "Already in use"
+
+
 # JSON payload containing access token
 class Token(SQLModel):
     access_token: str

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -128,8 +128,12 @@ def test_create_user_existing_username(
         json=data,
     )
     created_user = r.json()
-    assert r.status_code == 400
-    assert "_id" not in created_user
+    assert r.status_code == 409
+    assert created_user == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_create_user_by_normal_user(
@@ -316,8 +320,12 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 409
+    assert r.json() == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_update_user(

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -7,7 +7,7 @@ import {
 import { type SubmitHandler, useForm } from "react-hook-form"
 import { FiLock, FiUser } from "react-icons/fi"
 
-import type { UserRegister } from "@/client"
+import type { ApiError, UserRegister } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Field } from "@/components/ui/field"
 import { InputGroup } from "@/components/ui/input-group"
@@ -37,6 +37,7 @@ function SignUp() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<UserRegisterForm>({
     mode: "onBlur",
@@ -50,7 +51,22 @@ function SignUp() {
   })
 
   const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+    signUpMutation.mutate(data, {
+      onError: (err: ApiError) => {
+        // Map 409 Conflict to inline field error using API error shape
+        const status = err.status
+        const body = err.body as any
+        if (status === 409 && body?.error === "conflict") {
+          const field = (body.field as "email" | "full_name" | undefined) ?? "email"
+          const message = (body.message as string) ?? "Already in use"
+          setError(field as any, { type: "server", message })
+          return
+        }
+        // fallback to default handler
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(signUpMutation as any).options?.onError?.(err)
+      },
+    })
   }
 
   return (

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -78,7 +78,7 @@ test("Sign up with invalid email", async ({ page }) => {
   await expect(page.getByText("Invalid email address")).toBeVisible()
 })
 
-test("Sign up with existing email", async ({ page }) => {
+test("Sign up with existing email shows inline error", async ({ page }) => {
   const fullName = "Test User"
   const email = randomEmail()
   const password = randomPassword()
@@ -95,9 +95,8 @@ test("Sign up with existing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  // Expect inline form error near the email field
+  await expect(page.getByText("Already in use")).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {


### PR DESCRIPTION
Backend
- Add a standard APIError model (documented in OpenAPI) to describe error responses: {error, field, message}.
- Update POST /users and POST /users/signup to return HTTP 409 with a consistent JSON shape when an email is already in use (JSONResponse with {"error":"conflict","field":"email","message":"Already in use"}).
- Add OpenAPI response documentation for 409 on these endpoints.
- Update backend tests to expect 409 + the new error payload.

Frontend
- Update signup flow to accept ApiError and call setError when the API returns 409 conflict, mapping the APIError.field/message to an inline form error.
- Update Playwright test to attempt a duplicate signup and assert the inline message "Already in use" is visible.

Notes
- This makes duplicate signup handling consistent across the API surface and UX, and documents the error model in OpenAPI. Backend unit tests and the updated Playwright test were adjusted accordingly.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/4ob4p3l1v8ki](https://cosine.sh/cosinedemo/full-stack-demo/task/4ob4p3l1v8ki)
Author: James White
