### PR TITLE
Add multi-tenant organizations, memberships and org-scoped items (backend + frontend)

### DIFF
--- a/backend/app/alembic/versions/7b2a1f0c9ab1_add_organizations_memberships_and_item_org.py
+++ b/backend/app/alembic/versions/7b2a1f0c9ab1_add_organizations_memberships_and_item_org.py
@@ -1,0 +1,50 @@
+"""Add organizations, memberships and item.org_id
+
+Revision ID: 7b2a1f0c9ab1
+Revises: 1a31ce608336
+Create Date: 2025-10-27 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '7b2a1f0c9ab1'
+down_revision = '1a31ce608336'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'organization',
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    op.create_table(
+        'membership',
+        sa.Column('role', sa.String(length=50), nullable=False),
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('org_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['org_id'], ['organization.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_membership_user_org_unique', 'membership', ['user_id', 'org_id'], unique=True)
+
+    # add org_id to item (nullable for back-compat)
+    op.add_column('item', sa.Column('org_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(None, 'item', 'organization', ['org_id'], ['id'], ondelete='CASCADE')
+
+
+def downgrade():
+    op.drop_constraint(None, 'item', type_='foreignkey')
+    op.drop_column('item', 'org_id')
+    op.drop_index('ix_membership_user_org_unique', table_name='membership')
+    op.drop_table('membership')
+    op.drop_table('organization')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -6,12 +6,12 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 from pydantic import ValidationError
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.core import security
 from app.core.config import settings
 from app.core.db import engine
-from app.models import TokenPayload, User
+from app.models import Membership, Organization, RoleEnum, TokenPayload, User
 
 reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl=f"{settings.API_V1_STR}/login/access-token"
@@ -55,3 +55,38 @@ def get_current_active_superuser(current_user: CurrentUser) -> User:
             status_code=403, detail="The user doesn't have enough privileges"
         )
     return current_user
+
+
+class ActiveOrg:
+    def __init__(self, org: Organization | None, role: RoleEnum | None):
+        self.org = org
+        self.role = role
+
+
+def get_active_org(session: SessionDep, token: TokenDep, current_user: CurrentUser) -> ActiveOrg:
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
+        )
+        token_data = TokenPayload(**payload)
+    except (InvalidTokenError, ValidationError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Could not validate credentials",
+        )
+    org = None
+    role: RoleEnum | None = None
+    if token_data.active_org_id:
+        org = session.get(Organization, token_data.active_org_id)
+        if org:
+            statement = select(Membership).where(
+                Membership.user_id == current_user.id, Membership.org_id == org.id
+            )
+            membership = session.exec(statement).first()
+            if not membership:
+                raise HTTPException(status_code=403, detail="Not a member of active organization")
+            role = membership.role
+    return ActiveOrg(org, role)
+
+
+ActiveOrgDep = Annotated[ActiveOrg, Depends(get_active_org)]

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.routes import items, login, private, users, utils
+from app.api.routes import orgs, memberships
 from app.core.config import settings
 
 api_router = APIRouter()
@@ -8,6 +9,8 @@ api_router.include_router(login.router)
 api_router.include_router(users.router)
 api_router.include_router(utils.router)
 api_router.include_router(items.router)
+api_router.include_router(orgs.router)
+api_router.include_router(memberships.router)
 
 
 if settings.ENVIRONMENT == "local":

--- a/backend/app/api/routes/items.py
+++ b/backend/app/api/routes/items.py
@@ -4,7 +4,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from sqlmodel import func, select
 
-from app.api.deps import CurrentUser, SessionDep
+from app.api.deps import ActiveOrgDep, CurrentUser, SessionDep
 from app.models import Item, ItemCreate, ItemPublic, ItemsPublic, ItemUpdate, Message
 
 router = APIRouter(prefix="/items", tags=["items"])
@@ -12,56 +12,79 @@ router = APIRouter(prefix="/items", tags=["items"])
 
 @router.get("/", response_model=ItemsPublic)
 def read_items(
-    session: SessionDep, current_user: CurrentUser, skip: int = 0, limit: int = 100
+    session: SessionDep, current_user: CurrentUser, active_org: ActiveOrgDep, skip: int = 0, limit: int = 100
 ) -> Any:
     """
-    Retrieve items.
+    Retrieve items scoped by active organization.
     """
-
-    if current_user.is_superuser:
+    if current_user.is_superuser and not active_org.org:
         count_statement = select(func.count()).select_from(Item)
         count = session.exec(count_statement).one()
         statement = select(Item).offset(skip).limit(limit)
         items = session.exec(statement).all()
     else:
-        count_statement = (
-            select(func.count())
-            .select_from(Item)
-            .where(Item.owner_id == current_user.id)
-        )
-        count = session.exec(count_statement).one()
-        statement = (
-            select(Item)
-            .where(Item.owner_id == current_user.id)
-            .offset(skip)
-            .limit(limit)
-        )
-        items = session.exec(statement).all()
+        if active_org.org:
+            count_statement = (
+                select(func.count())
+                .select_from(Item)
+                .where(Item.org_id == active_org.org.id)
+            )
+            count = session.exec(count_statement).one()
+            statement = (
+                select(Item)
+                .where(Item.org_id == active_org.org.id)
+                .offset(skip)
+                .limit(limit)
+            )
+            items = session.exec(statement).all()
+        else:
+            # fallback: personal items owned by user without org
+            count_statement = (
+                select(func.count())
+                .select_from(Item)
+                .where(Item.owner_id == current_user.id, Item.org_id.is_(None))  # type: ignore
+            )
+            count = session.exec(count_statement).one()
+            statement = (
+                select(Item)
+                .where(Item.owner_id == current_user.id, Item.org_id.is_(None))  # type: ignore
+                .offset(skip)
+                .limit(limit)
+            )
+            items = session.exec(statement).all()
 
     return ItemsPublic(data=items, count=count)
 
 
 @router.get("/{id}", response_model=ItemPublic)
-def read_item(session: SessionDep, current_user: CurrentUser, id: uuid.UUID) -> Any:
+def read_item(session: SessionDep, current_user: CurrentUser, active_org: ActiveOrgDep, id: uuid.UUID) -> Any:
     """
     Get item by ID.
     """
     item = session.get(Item, id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
-    if not current_user.is_superuser and (item.owner_id != current_user.id):
-        raise HTTPException(status_code=400, detail="Not enough permissions")
+    if not current_user.is_superuser:
+        if item.org_id is None:
+            if item.owner_id != current_user.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
+        else:
+            if not active_org.org or item.org_id != active_org.org.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
     return item
 
 
 @router.post("/", response_model=ItemPublic)
 def create_item(
-    *, session: SessionDep, current_user: CurrentUser, item_in: ItemCreate
+    *, session: SessionDep, current_user: CurrentUser, active_org: ActiveOrgDep, item_in: ItemCreate
 ) -> Any:
     """
-    Create new item.
+    Create new item in active organization.
     """
-    item = Item.model_validate(item_in, update={"owner_id": current_user.id})
+    if active_org.org:
+        item = Item.model_validate(item_in, update={"owner_id": current_user.id, "org_id": active_org.org.id})
+    else:
+        item = Item.model_validate(item_in, update={"owner_id": current_user.id})
     session.add(item)
     session.commit()
     session.refresh(item)
@@ -73,6 +96,7 @@ def update_item(
     *,
     session: SessionDep,
     current_user: CurrentUser,
+    active_org: ActiveOrgDep,
     id: uuid.UUID,
     item_in: ItemUpdate,
 ) -> Any:
@@ -82,8 +106,13 @@ def update_item(
     item = session.get(Item, id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
-    if not current_user.is_superuser and (item.owner_id != current_user.id):
-        raise HTTPException(status_code=400, detail="Not enough permissions")
+    if not current_user.is_superuser:
+        if item.org_id is None:
+            if item.owner_id != current_user.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
+        else:
+            if not active_org.org or item.org_id != active_org.org.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
     update_dict = item_in.model_dump(exclude_unset=True)
     item.sqlmodel_update(update_dict)
     session.add(item)
@@ -94,7 +123,7 @@ def update_item(
 
 @router.delete("/{id}")
 def delete_item(
-    session: SessionDep, current_user: CurrentUser, id: uuid.UUID
+    session: SessionDep, current_user: CurrentUser, active_org: ActiveOrgDep, id: uuid.UUID
 ) -> Message:
     """
     Delete an item.
@@ -102,8 +131,13 @@ def delete_item(
     item = session.get(Item, id)
     if not item:
         raise HTTPException(status_code=404, detail="Item not found")
-    if not current_user.is_superuser and (item.owner_id != current_user.id):
-        raise HTTPException(status_code=400, detail="Not enough permissions")
+    if not current_user.is_superuser:
+        if item.org_id is None:
+            if item.owner_id != current_user.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
+        else:
+            if not active_org.org or item.org_id != active_org.org.id:
+                raise HTTPException(status_code=400, detail="Not enough permissions")
     session.delete(item)
     session.commit()
     return Message(message="Item deleted successfully")

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -4,13 +4,14 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import select
 
 from app import crud
 from app.api.deps import CurrentUser, SessionDep, get_current_active_superuser
 from app.core import security
 from app.core.config import settings
 from app.core.security import get_password_hash
-from app.models import Message, NewPassword, Token, UserPublic
+from app.models import Membership, Message, NewPassword, Token, UserPublic
 from app.utils import (
     generate_password_reset_token,
     generate_reset_password_email,
@@ -36,9 +37,16 @@ def login_access_token(
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+
+    # choose first organization the user belongs to as active, if any
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == user.id)
+    ).first()
+    active_org_id = str(membership.org_id) if membership else None
+
     return Token(
         access_token=security.create_access_token(
-            user.id, expires_delta=access_token_expires
+            user.id, expires_delta=access_token_expires, active_org_id=active_org_id
         )
     )
 

--- a/backend/app/api/routes/memberships.py
+++ b/backend/app/api/routes/memberships.py
@@ -1,0 +1,87 @@
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from sqlmodel import func, select
+
+from app.api.deps import ActiveOrgDep, CurrentUser, SessionDep
+from app.models import (
+    Membership,
+    MembershipCreate,
+    MembershipPublic,
+    MembershipUpdate,
+    MembershipsPublic,
+    Organization,
+    RoleEnum,
+    User,
+)
+
+router = APIRouter(prefix="/memberships", tags=["memberships"])
+
+
+def ensure_admin(session: SessionDep, user_id: uuid.UUID, org_id: uuid.UUID) -> None:
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == user_id, Membership.org_id == org_id)
+    ).first()
+    if not membership or membership.role != RoleEnum.admin:
+        raise HTTPException(status_code=403, detail="Only admins can perform this action")
+
+
+@router.get("/org/{org_id}", response_model=MembershipsPublic)
+def list_members(session: SessionDep, current_user: CurrentUser, org_id: uuid.UUID) -> Any:
+    # only members can list
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == current_user.id, Membership.org_id == org_id)
+    ).first()
+    if not membership and not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    statement = select(Membership).where(Membership.org_id == org_id)
+    members = session.exec(statement).all()
+    return MembershipsPublic(data=members, count=len(members))
+
+
+@router.post("/", response_model=MembershipPublic)
+def add_member(session: SessionDep, current_user: CurrentUser, membership_in: MembershipCreate) -> Any:
+    # admin check
+    ensure_admin(session, current_user.id, membership_in.org_id)
+    # verify user and org exist
+    if not session.get(User, membership_in.user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    if not session.get(Organization, membership_in.org_id):
+        raise HTTPException(status_code=404, detail="Organization not found")
+    exists = session.exec(
+        select(Membership).where(
+            Membership.user_id == membership_in.user_id, Membership.org_id == membership_in.org_id
+        )
+    ).first()
+    if exists:
+        raise HTTPException(status_code=409, detail="User already a member")
+    member = Membership.model_validate(membership_in)
+    session.add(member)
+    session.commit()
+    session.refresh(member)
+    return member
+
+
+@router.patch("/{membership_id}", response_model=MembershipPublic)
+def update_member(session: SessionDep, current_user: CurrentUser, membership_id: uuid.UUID, membership_in: MembershipUpdate) -> Any:
+    db_member = session.get(Membership, membership_id)
+    if not db_member:
+        raise HTTPException(status_code=404, detail="Membership not found")
+    ensure_admin(session, current_user.id, db_member.org_id)
+    db_member.sqlmodel_update(membership_in.model_dump(exclude_unset=True))
+    session.add(db_member)
+    session.commit()
+    session.refresh(db_member)
+    return db_member
+
+
+@router.delete("/{membership_id}")
+def remove_member(session: SessionDep, current_user: CurrentUser, membership_id: uuid.UUID) -> Any:
+    db_member = session.get(Membership, membership_id)
+    if not db_member:
+        raise HTTPException(status_code=404, detail="Membership not found")
+    ensure_admin(session, current_user.id, db_member.org_id)
+    session.delete(db_member)
+    session.commit()
+    return {"message": "Member removed successfully"}

--- a/backend/app/api/routes/orgs.py
+++ b/backend/app/api/routes/orgs.py
@@ -1,0 +1,121 @@
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from sqlmodel import func, select
+
+from app.api.deps import ActiveOrgDep, CurrentUser, SessionDep
+from app.core import security
+from app.core.config import settings
+from app.models import (
+    Membership,
+    MembershipPublic,
+    Organization,
+    OrganizationCreate,
+    OrganizationPublic,
+    OrganizationUpdate,
+    OrganizationsPublic,
+    RoleEnum,
+    Token,
+)
+
+router = APIRouter(prefix="/orgs", tags=["organizations"])
+
+
+@router.get("/my", response_model=OrganizationsPublic)
+def list_my_orgs(session: SessionDep, current_user: CurrentUser) -> Any:
+    statement = (
+        select(Organization)
+        .join(Membership, Membership.org_id == Organization.id)
+        .where(Membership.user_id == current_user.id)
+    )
+    orgs = session.exec(statement).all()
+    count = len(orgs)
+    return OrganizationsPublic(data=orgs, count=count)
+
+
+@router.post("/", response_model=OrganizationPublic)
+def create_org(session: SessionDep, current_user: CurrentUser, org_in: OrganizationCreate) -> Any:
+    org = Organization.model_validate(org_in)
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    # add creator as admin member
+    member = Membership(user_id=current_user.id, org_id=org.id, role=RoleEnum.admin)
+    session.add(member)
+    session.commit()
+    return org
+
+
+@router.get("/{org_id}", response_model=OrganizationPublic)
+def get_org(session: SessionDep, current_user: CurrentUser, org_id: uuid.UUID) -> Any:
+    org = session.get(Organization, org_id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    # must be a member
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == current_user.id, Membership.org_id == org_id)
+    ).first()
+    if not membership and not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    return org
+
+
+@router.patch("/{org_id}", response_model=OrganizationPublic)
+def update_org(
+    session: SessionDep, active_org: ActiveOrgDep, current_user: CurrentUser, org_id: uuid.UUID, org_in: OrganizationUpdate
+) -> Any:
+    org = session.get(Organization, org_id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    # require admin
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == current_user.id, Membership.org_id == org_id)
+    ).first()
+    if not (current_user.is_superuser or (membership and membership.role == RoleEnum.admin)):
+        raise HTTPException(status_code=403, detail="Only admins can update organization")
+    update_data = org_in.model_dump(exclude_unset=True)
+    org.sqlmodel_update(update_data)
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    return org
+
+
+@router.delete("/{org_id}")
+def delete_org(session: SessionDep, current_user: CurrentUser, org_id: uuid.UUID) -> Any:
+    org = session.get(Organization, org_id)
+    if not org:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == current_user.id, Membership.org_id == org_id)
+    ).first()
+    if not (current_user.is_superuser or (membership and membership.role == RoleEnum.admin)):
+        raise HTTPException(status_code=403, detail="Only admins can delete organization")
+    session.delete(org)
+    session.commit()
+    return {"message": "Organization deleted successfully"}
+
+
+@router.post("/switch/{org_id}", response_model=Token)
+def switch_active_org(session: SessionDep, current_user: CurrentUser, org_id: uuid.UUID) -> Token:
+    # verify membership
+    membership = session.exec(
+        select(Membership).where(Membership.user_id == current_user.id, Membership.org_id == org_id)
+    ).first()
+    if not membership and not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="Not a member of this organization")
+    access_token = security.create_access_token(
+        current_user.id,
+        expires_delta=(
+            settings.ACCESS_TOKEN_EXPIRE_MINUTES  # type: ignore[arg-type]
+        )
+        and None,  # will be replaced below
+    )
+    # The helper expects timedelta, compute it properly
+    from datetime import timedelta
+
+    access_token = security.create_access_token(
+        current_user.id, expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES), active_org_id=str(org_id)
+    )
+    return Token(access_token=access_token)

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -2,7 +2,14 @@ from sqlmodel import Session, create_engine, select
 
 from app import crud
 from app.core.config import settings
-from app.models import User, UserCreate
+from app.models import (
+    ItemCreate,
+    Membership,
+    Organization,
+    RoleEnum,
+    User,
+    UserCreate,
+)
 
 engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI))
 
@@ -21,13 +28,66 @@ def init_db(session: Session) -> None:
     # This works because the models are already imported and registered from app.models
     # SQLModel.metadata.create_all(engine)
 
-    user = session.exec(
+    superuser = session.exec(
         select(User).where(User.email == settings.FIRST_SUPERUSER)
     ).first()
-    if not user:
+    if not superuser:
         user_in = UserCreate(
             email=settings.FIRST_SUPERUSER,
             password=settings.FIRST_SUPERUSER_PASSWORD,
             is_superuser=True,
         )
-        user = crud.create_user(session=session, user_create=user_in)
+        superuser = crud.create_user(session=session, user_create=user_in)
+
+    # ensure test user exists
+    test_user = session.exec(select(User).where(User.email == settings.EMAIL_TEST_USER)).first()
+    if not test_user:
+        test_user = crud.create_user(
+            session=session,
+            user_create=UserCreate(email=settings.EMAIL_TEST_USER, password="testpassword123"),
+        )
+
+    # Seed two organizations and memberships
+    org1 = session.exec(select(Organization).where(Organization.name == "Acme")).first()
+    if not org1:
+        org1 = Organization(name="Acme")
+        session.add(org1)
+        session.commit()
+        session.refresh(org1)
+    org2 = session.exec(select(Organization).where(Organization.name == "Globex")).first()
+    if not org2:
+        org2 = Organization(name="Globex")
+        session.add(org2)
+        session.commit()
+        session.refresh(org2)
+
+    # add memberships (idempotent)
+    def ensure_membership(user_id, org_id, role: RoleEnum):
+        exists = session.exec(
+            select(Membership).where(Membership.user_id == user_id, Membership.org_id == org_id)
+        ).first()
+        if not exists:
+            m = Membership(user_id=user_id, org_id=org_id, role=role)
+            session.add(m)
+            session.commit()
+
+    if superuser:
+        ensure_membership(superuser.id, org1.id, RoleEnum.admin)
+        ensure_membership(superuser.id, org2.id, RoleEnum.admin)
+    if test_user:
+        ensure_membership(test_user.id, org1.id, RoleEnum.member)
+
+    # create a sample item in org1 for superuser
+    if superuser:
+        existing_item = session.exec(
+            select(User, Organization)
+            .where(User.id == superuser.id)
+        ).first()
+        item_in = ItemCreate(title="Welcome Item", description="Seeded item")
+        # create via crud to preserve pattern; org set at route usually, set manually here
+        from app.models import Item
+        item = session.exec(select(Item).where(Item.title == item_in.title)).first()
+        if not item:
+            item = Item.model_validate(item_in, update={"owner_id": superuser.id, "org_id": org1.id})
+            session.add(item)
+            session.commit()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -12,9 +12,11 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 ALGORITHM = "HS256"
 
 
-def create_access_token(subject: str | Any, expires_delta: timedelta) -> str:
+def create_access_token(subject: str | Any, expires_delta: timedelta, active_org_id: str | None = None) -> str:
     expire = datetime.now(timezone.utc) + expires_delta
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode: dict[str, Any] = {"exp": expire, "sub": str(subject)}
+    if active_org_id:
+        to_encode["active_org_id"] = str(active_org_id)
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,5 @@
 import uuid
+from enum import Enum
 
 from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
@@ -44,6 +45,7 @@ class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str
     items: list["Item"] = Relationship(back_populates="owner", cascade_delete=True)
+    memberships: list["Membership"] = Relationship(back_populates="user", cascade_delete=True)
 
 
 # Properties to return via API, id is always required
@@ -53,6 +55,72 @@ class UserPublic(UserBase):
 
 class UsersPublic(SQLModel):
     data: list[UserPublic]
+    count: int
+
+
+# Organization models
+class OrganizationBase(SQLModel):
+    name: str = Field(min_length=1, max_length=255)
+
+
+class OrganizationCreate(OrganizationBase):
+    pass
+
+
+class OrganizationUpdate(SQLModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)  # type: ignore
+
+
+class Organization(OrganizationBase, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    items: list["Item"] = Relationship(back_populates="organization", cascade_delete=True)
+    memberships: list["Membership"] = Relationship(back_populates="organization", cascade_delete=True)
+
+
+class OrganizationPublic(OrganizationBase):
+    id: uuid.UUID
+
+
+class OrganizationsPublic(SQLModel):
+    data: list[OrganizationPublic]
+    count: int
+
+
+# Membership models
+class RoleEnum(str, Enum):
+    admin = "admin"
+    member = "member"
+
+
+class MembershipBase(SQLModel):
+    role: RoleEnum = RoleEnum.member
+
+
+class MembershipCreate(MembershipBase):
+    user_id: uuid.UUID
+    org_id: uuid.UUID
+
+
+class MembershipUpdate(MembershipBase):
+    pass
+
+
+class Membership(MembershipBase, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(foreign_key="user.id", nullable=False, ondelete="CASCADE")
+    org_id: uuid.UUID = Field(foreign_key="organization.id", nullable=False, ondelete="CASCADE")
+    user: User | None = Relationship(back_populates="memberships")
+    organization: Organization | None = Relationship(back_populates="memberships")
+
+
+class MembershipPublic(MembershipBase):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    org_id: uuid.UUID
+
+
+class MembershipsPublic(SQLModel):
+    data: list[MembershipPublic]
     count: int
 
 
@@ -78,13 +146,18 @@ class Item(ItemBase, table=True):
     owner_id: uuid.UUID = Field(
         foreign_key="user.id", nullable=False, ondelete="CASCADE"
     )
+    org_id: uuid.UUID | None = Field(
+        foreign_key="organization.id", nullable=True, ondelete="CASCADE"
+    )
     owner: User | None = Relationship(back_populates="items")
+    organization: Organization | None = Relationship(back_populates="items")
 
 
 # Properties to return via API, id is always required
 class ItemPublic(ItemBase):
     id: uuid.UUID
     owner_id: uuid.UUID
+    org_id: uuid.UUID | None = None
 
 
 class ItemsPublic(SQLModel):
@@ -106,6 +179,7 @@ class Token(SQLModel):
 # Contents of JWT token
 class TokenPayload(SQLModel):
     sub: str | None = None
+    active_org_id: str | None = None
 
 
 class NewPassword(SQLModel):

--- a/frontend/src/components/Common/Navbar.tsx
+++ b/frontend/src/components/Common/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router"
 
 import Logo from "/assets/images/fastapi-logo.svg"
 import UserMenu from "./UserMenu"
+import OrgSwitcher from "./OrgSwitcher"
 
 function Navbar() {
   const display = useBreakpointValue({ base: "none", md: "flex" })
@@ -23,6 +24,7 @@ function Navbar() {
         <Image src={Logo} alt="Logo" maxW="3xs" p={2} />
       </Link>
       <Flex gap={2} alignItems="center">
+        <OrgSwitcher />
         <UserMenu />
       </Flex>
     </Flex>

--- a/frontend/src/components/Common/OrgSwitcher.tsx
+++ b/frontend/src/components/Common/OrgSwitcher.tsx
@@ -1,0 +1,58 @@
+import { Button, Menu, MenuContent, MenuItem, MenuTrigger } from "@chakra-ui/react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { OpenAPI } from "@/client"
+
+type Org = { id: string; name: string }
+
+async function fetchMyOrgs(): Promise<Org[]> {
+  const res = await fetch(`${OpenAPI.BASE}/api/v1/orgs/my`, {
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem("access_token") || ""}`,
+    },
+  })
+  if (!res.ok) throw new Error("Failed to load orgs")
+  const data = await res.json()
+  return data.data as Org[]
+}
+
+async function switchOrg(orgId: string): Promise<void> {
+  const res = await fetch(`${OpenAPI.BASE}/api/v1/orgs/switch/${orgId}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem("access_token") || ""}`,
+    },
+  })
+  if (!res.ok) throw new Error("Failed to switch organization")
+  const data = await res.json()
+  localStorage.setItem("access_token", data.access_token)
+}
+
+export default function OrgSwitcher() {
+  const queryClient = useQueryClient()
+  const { data: orgs = [] } = useQuery({ queryKey: ["my-orgs"], queryFn: fetchMyOrgs })
+
+  const onSelect = async (org: Org) => {
+    await switchOrg(org.id)
+    // invalidate queries to reload with new token/org
+    queryClient.invalidateQueries()
+  }
+
+  if (orgs.length === 0) return null
+
+  return (
+    <Menu>
+      <MenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          Switch Org
+        </Button>
+      </MenuTrigger>
+      <MenuContent>
+        {orgs.map((org) => (
+          <MenuItem key={org.id} onClick={() => onSelect(org)}>
+            {org.name}
+          </MenuItem>
+        ))}
+      </MenuContent>
+    </Menu>
+  )
+}

--- a/frontend/src/routes/_layout/org-members.tsx
+++ b/frontend/src/routes/_layout/org-members.tsx
@@ -1,0 +1,52 @@
+import { Container, Heading, Table } from "@chakra-ui/react"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { OpenAPI } from "@/client"
+
+type Member = { id: string; user_id: string; org_id: string; role: string }
+
+async function fetchMembers(): Promise<Member[]> {
+  // we need active org id, which backend reads from token
+  const res = await fetch(`${OpenAPI.BASE}/api/v1/orgs/my`, {
+    headers: { Authorization: `Bearer ${localStorage.getItem("access_token") || ""}` },
+  })
+  const data = await res.json()
+  const orgs: { id: string }[] = data.data || []
+  const activeMembersRes = await fetch(`${OpenAPI.BASE}/api/v1/memberships/org/${orgs[0]?.id}`, {
+    headers: { Authorization: `Bearer ${localStorage.getItem("access_token") || ""}` },
+  })
+  const membersData = await activeMembersRes.json()
+  return membersData.data as Member[]
+}
+
+export const Route = createFileRoute("/_layout/org-members")({
+  component: OrgMembers,
+})
+
+function OrgMembers() {
+  const { data: members = [] } = useQuery({ queryKey: ["org-members"], queryFn: fetchMembers })
+
+  return (
+    <Container maxW="full">
+      <Heading size="lg" pt={12}>
+        Organization Members
+      </Heading>
+      <Table.Root mt={4}>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>User ID</Table.ColumnHeader>
+            <Table.ColumnHeader>Role</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {members.map((m) => (
+            <Table.Row key={m.id}>
+              <Table.Cell>{m.user_id}</Table.Cell>
+              <Table.Cell>{m.role}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Container>
+  )
+}


### PR DESCRIPTION
Summary

This PR implements multi-tenancy via Organizations and Memberships and scopes items to an active organization. It includes the DB migration, backend API changes (CRUD for orgs & memberships, RBAC checks, token changes), frontend UI (org switcher + members page), and seed data to get started.

What changed (high level)

- Database
  - Added Alembic migration to create organization and membership tables and to add org_id to item (nullable for back-compat).
  - Seed logic in app.core.db.init_db creates two orgs ("Acme" and "Globex"), a test user, memberships, and a sample item.

- Models
  - New Organization and Membership models and DTOs. RoleEnum defines admin/member roles.
  - Item now has an optional org_id and relationship to Organization.
  - Token payload includes active_org_id.

- Security / Auth
  - create_access_token now accepts active_org_id and stores it in the JWT.
  - On login we pick the first org the user belongs to (if any) as the default active org and include it in the issued token.
  - New dependency get_active_org validates active_org_id from the token, loads the org, and loads the caller's membership/role (used for RBAC).

- API
  - New routes: /api/v1/orgs (list my orgs, create, get, update, delete, switch active org) and /api/v1/memberships (list, add, update, remove).
  - Only admins can invite/remove/update membership entries (enforced in memberships routes and org update/delete).
  - switch active org endpoint returns a new token with active_org_id set.
  - Items endpoints updated to be org-aware:
    - Superusers can see everything unless an active org is set.
    - When an active org is set, items are read/written by org_id.
    - When no active org, users operate on their personal items (org_id is null).
    - All item read/update/delete endpoints enforce membership and org scoping.

- Frontend
  - Navbar imports a new OrgSwitcher component.
  - OrgSwitcher lists the user's orgs and calls the switch endpoint; it stores the returned token in localStorage so subsequent requests use the new active org.
  - Added an Organization Members page that calls memberships for the (first) organization returned by /orgs/my (simple placeholder for members management/listing).

Files of note

- Migration: backend/app/alembic/versions/7b2a1f0c9ab1_add_organizations_memberships_and_item_org.py
- Backend deps and models: backend/app/api/deps.py, backend/app/models.py, backend/app/core/security.py
- DB seed: backend/app/core/db.py (seeds two orgs, memberships, and a sample item)
- New routes: backend/app/api/routes/orgs.py, backend/app/api/routes/memberships.py
- Modified routes: backend/app/api/routes/items.py, backend/app/api/routes/login.py
- Main router registration: backend/app/api/main.py
- Frontend components: frontend/src/components/Common/OrgSwitcher.tsx, frontend/src/components/Common/Navbar.tsx
- Frontend page: frontend/src/routes/_layout/org-members.tsx

Notes & usage

- Run migrations: alembic upgrade head
- Start backend so init_db seeds organizations and memberships (or run the seed logic manually if you disabled init_db).
- Login as a user and the token will include an active_org_id if the user belongs to an org. Use the frontend OrgSwitcher or POST /api/v1/orgs/switch/{org_id} to receive a new token with a different active_org_id.
- Items are scoped by the active organization when set. If no active org is set, users operate on personal items (item.org_id == null).
- RBAC: only users with RoleEnum.admin in an org (or superusers) can add/update/delete memberships or update/delete orgs.
- Backwards compatibility: item.org_id is nullable to preserve personal items. Superusers retain elevated access when no active org is set.

Testing / Next steps

- The PR implements the core functionality and seed data. The DoD in the issue mentions pytest and Playwright tests and docs; those will be added in follow-ups (or can be merged alongside if you prefer). For now you can manually exercise invite/switch/list flows via the API or the small frontend components included.

If anything should be adjusted (endpoints, token behavior, or seeding), I can update the PR accordingly.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/1dczvw5olng0](https://cosine.sh/cosinedemo/full-stack-demo/task/1dczvw5olng0)
Author: James White
