### PR TITLE
Return 409 Conflict for duplicate signup/email with a consistent error payload; add error model, frontend mapping, and tests

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -23,6 +24,7 @@ from app.models import (
     UsersPublic,
     UserUpdate,
     UserUpdateMe,
+    ErrorResponse,
 )
 from app.utils import generate_new_account_email, send_email
 
@@ -49,7 +51,10 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
+    "/",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=UserPublic,
+    responses={409: {"model": ErrorResponse, "description": "Conflict"}},
 )
 def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
@@ -57,9 +62,9 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system.",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email", "message": "Already in use"},
         )
 
     user = crud.create_user(session=session, user_create=user_in)
@@ -139,16 +144,20 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
     return Message(message="User deleted successfully")
 
 
-@router.post("/signup", response_model=UserPublic)
+@router.post(
+    "/signup",
+    response_model=UserPublic,
+    responses={409: {"model": ErrorResponse, "description": "Conflict"}},
+)
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     Create new user without the need to be logged in.
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email", "message": "Already in use"},
         )
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -97,6 +97,13 @@ class Message(SQLModel):
     message: str
 
 
+# Consistent error response model for OpenAPI documentation
+class ErrorResponse(SQLModel):
+    error: str  # e.g. "conflict"
+    field: str  # e.g. "email"
+    message: str  # e.g. "Already in use"
+
+
 # JSON payload containing access token
 class Token(SQLModel):
     access_token: str

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -127,9 +127,8 @@ def test_create_user_existing_username(
         headers=superuser_token_headers,
         json=data,
     )
-    created_user = r.json()
-    assert r.status_code == 400
-    assert "_id" not in created_user
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "email", "message": "Already in use"}
 
 
 def test_create_user_by_normal_user(
@@ -316,8 +315,8 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "email", "message": "Already in use"}
 
 
 def test_update_user(

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -7,13 +7,13 @@ import {
 import { type SubmitHandler, useForm } from "react-hook-form"
 import { FiLock, FiUser } from "react-icons/fi"
 
-import type { UserRegister } from "@/client"
+import type { ApiError, UserRegister } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Field } from "@/components/ui/field"
 import { InputGroup } from "@/components/ui/input-group"
 import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
-import { confirmPasswordRules, emailPattern, passwordRules } from "@/utils"
+import { confirmPasswordRules, emailPattern, passwordRules, handleError } from "@/utils"
 import Logo from "/assets/images/fastapi-logo.svg"
 
 export const Route = createFileRoute("/signup")({
@@ -37,6 +37,7 @@ function SignUp() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<UserRegisterForm>({
     mode: "onBlur",
@@ -50,7 +51,25 @@ function SignUp() {
   })
 
   const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+    signUpMutation.mutate(data, {
+      onError: (err: ApiError) => {
+        // Map API 409 conflict to inline form errors
+        if (err.status === 409) {
+          const body = err.body as any
+          const field = body?.field
+          const message = body?.message || "Already in use"
+          if (field) {
+            setError(field as "email" | "full_name" | "password", {
+              type: "server",
+              message,
+            })
+            return
+          }
+        }
+        // Fallback to global error handling
+        handleError(err)
+      },
+    })
   }
 
   return (

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -95,9 +95,8 @@ test("Sign up with existing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  // Expect inline field error
+  await expect(page.getByText("Already in use")).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {


### PR DESCRIPTION
Summary:
- API now returns HTTP 409 Conflict for duplicate emails/usernames with a consistent error payload: {"error":"conflict","field":"email","message":"Already in use"}.
- Adds a dedicated error model for OpenAPI and wires 409 responses for signup flows.
- Frontend maps 409 errors to inline form errors and includes a Playwright test to verify the behavior.

Backend changes:
- Introduced a standardized error model (ErrorResponse) to describe 409 conflicts in OpenAPI documentation.
- Updated user routes to return a 409 Conflict when a duplicate email is detected in both create_user and signup paths, using a JSON payload:
  {"error":"conflict","field":"email","message":"Already in use"}.
- Declared 409 responses in the route definitions with a reference to ErrorResponse for OpenAPI docs.
- Note: backend now enforces a defensive check for duplicates and prepares for DB unique constraints; actual migrations/constraints are out of this patch scope.

Tests:
- Backend tests were updated to expect status code 409 and the exact error payload when a duplicate email is used.
  Expected body: {"error":"conflict","field":"email","message":"Already in use"}.

Frontend changes:
- Updated signup flow to map API 409 errors to inline form errors. If the API returns {error, field, message}, the corresponding field on the form is marked with the server error message.
- Modified frontend code to handle 409 in the sign-up mutation and set inline errors accordingly (field-based error on email, etc.).
- Playwright test updated to attempt a duplicate signup and verify the inline message appears (e.g., "Already in use").

OpenAPI/documentation:
- Added ErrorResponse model and wired 409 responses so clients can rely on the standardized error shape across endpoints.

Impact:
- Consumers will receive a predictable 409 Conflict with a consistent error payload for duplicate signups, enabling better UX and validation handling on the frontend.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/dwyvv2crfugv](https://cosine.sh/cosinedemo/full-stack-demo/task/dwyvv2crfugv)
Author: James White
