### PR TITLE
Add pluggable notifications (console/SMTP) with background sending and optimistic forgot-password UI

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ SECRET_KEY=changethis
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
 
-# Emails
+# Emails / notifications
 SMTP_HOST=
 SMTP_USER=
 SMTP_PASSWORD=
@@ -30,6 +30,8 @@ EMAILS_FROM_EMAIL=info@example.com
 SMTP_TLS=True
 SMTP_SSL=False
 SMTP_PORT=587
+# Notification provider: "console" logs emails instead of sending, useful for local dev
+NOTIFICATIONS_PROVIDER=console
 
 # Postgres
 POSTGRES_SERVER=localhost

--- a/README.md
+++ b/README.md
@@ -216,6 +216,47 @@ The input variables, with their default values (some auto generated) are:
 
 Backend docs: [backend/README.md](./backend/README.md).
 
+### Notifications
+
+The backend sends emails for:
+
+- Welcome emails when an admin creates a user.
+- Password recovery emails when a user requests a reset link.
+
+These flows are implemented in `app/notifications` and use a pluggable provider:
+
+- `console`: logs the email content to the console (useful for local development).
+- `smtp`: sends real emails using the SMTP configuration.
+
+The provider is configured via environment variables, using Pydantic settings:
+
+- `NOTIFICATIONS_PROVIDER` – one of `console` or `smtp`.
+- Standard SMTP settings: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`,
+  `SMTP_TLS`, `SMTP_SSL`, `EMAILS_FROM_EMAIL`.
+
+Example local configuration (in `.env`):
+
+```env
+# Emails / notifications
+SMTP_HOST=
+SMTP_USER=
+SMTP_PASSWORD=
+EMAILS_FROM_EMAIL=info@example.com
+SMTP_TLS=True
+SMTP_SSL=False
+SMTP_PORT=587
+# Notification provider: "console" logs emails instead of sending, useful for local dev
+NOTIFICATIONS_PROVIDER=console
+```
+
+To switch providers:
+
+1. Set `NOTIFICATIONS_PROVIDER` in `.env`:
+   - `NOTIFICATIONS_PROVIDER=console` to log emails.
+   - `NOTIFICATIONS_PROVIDER=smtp` to send real emails via SMTP.
+2. Ensure your SMTP settings are correct when using `smtp`.
+3. Restart the backend so the new settings are loaded.
+
 ## Frontend Development
 
 Frontend docs: [frontend/README.md](./frontend/README.md).

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -11,10 +11,9 @@ from app.core import security
 from app.core.config import settings
 from app.core.security import get_password_hash
 from app.models import Message, NewPassword, Token, UserPublic
+from app.notifications.service import send_password_recovery_email
 from app.utils import (
     generate_password_reset_token,
-    generate_reset_password_email,
-    send_email,
     verify_password_reset_token,
 )
 
@@ -52,7 +51,11 @@ def test_token(current_user: CurrentUser) -> Any:
 
 
 @router.post("/password-recovery/{email}")
-def recover_password(email: str, session: SessionDep) -> Message:
+def recover_password(
+    email: str,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+) -> Message:
     """
     Password Recovery
     """
@@ -64,13 +67,11 @@ def recover_password(email: str, session: SessionDep) -> Message:
             detail="The user with this email does not exist in the system.",
         )
     password_reset_token = generate_password_reset_token(email=email)
-    email_data = generate_reset_password_email(
-        email_to=user.email, email=email, token=password_reset_token
-    )
-    send_email(
+    background_tasks.add_task(
+        send_password_recovery_email,
         email_to=user.email,
-        subject=email_data.subject,
-        html_content=email_data.html_content,
+        email=email,
+        token=password_reset_token,
     )
     return Message(message="Password recovery email sent")
 

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -24,7 +24,7 @@ from app.models import (
     UserUpdate,
     UserUpdateMe,
 )
-from app.utils import generate_new_account_email, send_email
+from app.notifications.service import send_welcome_email
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -51,7 +51,12 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(
+    *,
+    session: SessionDep,
+    user_in: UserCreate,
+    background_tasks: BackgroundTasks,
+) -> Any:
     """
     Create new user.
     """
@@ -64,13 +69,11 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
 
     user = crud.create_user(session=session, user_create=user_in)
     if settings.emails_enabled and user_in.email:
-        email_data = generate_new_account_email(
-            email_to=user_in.email, username=user_in.email, password=user_in.password
-        )
-        send_email(
+        background_tasks.add_task(
+            send_welcome_email,
             email_to=user_in.email,
-            subject=email_data.subject,
-            html_content=email_data.html_content,
+            username=user_in.email,
+            password=user_in.password,
         )
     return user
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str | None = None
     EMAILS_FROM_EMAIL: EmailStr | None = None
     EMAILS_FROM_NAME: EmailStr | None = None
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:

--- a/backend/app/notifications/models.py
+++ b/backend/app/notifications/models.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EmailMessage:
+    email_to: str
+    subject: str
+    html_content: str

--- a/backend/app/notifications/providers.py
+++ b/backend/app/notifications/providers.py
@@ -1,0 +1,75 @@
+import logging
+from abc import ABC, abstractmethod
+
+import emails  # type: ignore
+
+from app.core.config import settings
+from app.notifications.models import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+
+class EmailProvider(ABC):
+    @abstractmethod
+    def send(self, message: EmailMessage) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ConsoleEmailProvider(EmailProvider):
+    def send(self, message: EmailMessage) -> None:
+        logger.info(
+            "Sending email via console provider",
+            extra={
+                "destination": message.email_to,
+                "subject": message.subject,
+                "provider": "console",
+            },
+        )
+        print(f"[EMAIL] To: {message.email_to} | Subject: {message.subject}")
+        print(message.html_content)
+
+
+class SmtpEmailProvider(EmailProvider):
+    def send(self, message: EmailMessage) -> None:
+        assert settings.emails_enabled, "no provided configuration for email variables"
+
+        logger.info(
+            "Sending email via SMTP provider",
+            extra={
+                "destination": message.email_to,
+                "subject": message.subject,
+                "provider": "smtp",
+                "host": settings.SMTP_HOST,
+                "port": settings.SMTP_PORT,
+            },
+        )
+
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+
+        message_to_send = emails.Message(
+            subject=message.subject,
+            html=message.html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        response = message_to_send.send(to=message.email_to, smtp=smtp_options)
+        logger.info(
+            "Email send completed",
+            extra={
+                "destination": message.email_to,
+                "subject": message.subject,
+                "provider": "smtp",
+                "result": str(response),
+            },
+        )

--- a/backend/app/notifications/service.py
+++ b/backend/app/notifications/service.py
@@ -1,0 +1,80 @@
+import logging
+
+from app.core.config import settings
+from app.notifications.models import EmailMessage
+from app.notifications.providers import ConsoleEmailProvider, EmailProvider, SmtpEmailProvider
+from app.utils import (
+    EmailData,
+    generate_new_account_email,
+    generate_reset_password_email,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_email_provider() -> EmailProvider:
+    if settings.NOTIFICATIONS_PROVIDER == "console":
+        return ConsoleEmailProvider()
+    if settings.NOTIFICATIONS_PROVIDER == "smtp":
+        return SmtpEmailProvider()
+    logger.warning(
+        "Unknown NOTIFICATIONS_PROVIDER, falling back to console",
+        extra={"provider": settings.NOTIFICATIONS_PROVIDER},
+    )
+    return ConsoleEmailProvider()
+
+
+def _email_data_to_message(email_to: str, email_data: EmailData) -> EmailMessage:
+    return EmailMessage(
+        email_to=email_to,
+        subject=email_data.subject,
+        html_content=email_data.html_content,
+    )
+
+
+def send_welcome_email(*, email_to: str, username: str, password: str) -> None:
+    if not settings.emails_enabled:
+        logger.info(
+            "Emails are disabled, skipping welcome email",
+            extra={"email_to": email_to},
+        )
+        return
+
+    email_data = generate_new_account_email(
+        email_to=email_to,
+        username=username,
+        password=password,
+    )
+    message = _email_data_to_message(email_to=email_to, email_data=email_data)
+    provider = get_email_provider()
+    try:
+        provider.send(message)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception(
+            "Failed to send welcome email",
+            extra={"email_to": email_to, "error": str(exc)},
+        )
+
+
+def send_password_recovery_email(*, email_to: str, email: str, token: str) -> None:
+    if not settings.emails_enabled:
+        logger.info(
+            "Emails are disabled, skipping password recovery email",
+            extra={"email_to": email_to},
+        )
+        return
+
+    email_data = generate_reset_password_email(
+        email_to=email_to,
+        email=email,
+        token=token,
+    )
+    message = _email_data_to_message(email_to=email_to, email_data=email_data)
+    provider = get_email_provider()
+    try:
+        provider.send(message)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception(
+            "Failed to send password recovery email",
+            extra={"email_to": email_to, "error": str(exc)},
+        )

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
@@ -28,31 +27,6 @@ def render_email_template(*, template_name: str, context: dict[str, Any]) -> str
     ).read_text()
     html_content = Template(template_str).render(context)
     return html_content
-
-
-def send_email(
-    *,
-    email_to: str,
-    subject: str = "",
-    html_content: str = "",
-) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
-        subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
-    )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/notifications/test_providers.py
+++ b/backend/tests/notifications/test_providers.py
@@ -1,0 +1,94 @@
+import logging
+
+import pytest
+
+from app.notifications.models import EmailMessage
+from app.notifications.providers import ConsoleEmailProvider, SmtpEmailProvider
+
+
+def test_console_provider_logs_and_prints(caplog, capsys):
+    provider = ConsoleEmailProvider()
+    message = EmailMessage(
+        email_to="user@example.com",
+        subject="Subject",
+        html_content="<p>Body</p>",
+    )
+
+    with caplog.at_level(logging.INFO):
+        provider.send(message)
+
+    assert any(
+        "Sending email via console provider" in record.getMessage()
+        for record in caplog.records
+    )
+
+    captured = capsys.readouterr()
+    assert "user@example.com" in captured.out
+    assert "Subject" in captured.out
+    assert "Body" in captured.out
+
+
+def test_smtp_provider_builds_message_and_logs(monkeypatch, caplog):
+    sent_messages: list[dict] = []
+
+    class DummyResponse:
+        def __str__(self) -> str:  # pragma: no cover - trivial
+            return "OK"
+
+    class DummyEmailsMessage:
+        def __init__(self, subject: str, html: str, mail_from: tuple[str, str | None]):
+            self.subject = subject
+            self.html = html
+            self.mail_from = mail_from
+
+        def send(self, to: str, smtp: dict) -> DummyResponse:
+            sent_messages.append(
+                {
+                    "to": to,
+                    "subject": self.subject,
+                    "html": self.html,
+                    "mail_from": self.mail_from,
+                    "smtp": smtp,
+                }
+            )
+            return DummyResponse()
+
+    monkeypatch.setattr("app.notifications.providers.emails.Message", DummyEmailsMessage)
+
+    from app.core.config import settings
+
+    settings.SMTP_HOST = "smtp.example.com"
+    settings.SMTP_PORT = 587
+    settings.SMTP_TLS = True
+    settings.SMTP_SSL = False
+    settings.SMTP_USER = "user"
+    settings.SMTP_PASSWORD = "pass"
+    settings.EMAILS_FROM_NAME = "Project"
+    settings.EMAILS_FROM_EMAIL = "noreply@example.com"
+
+    provider = SmtpEmailProvider()
+    message = EmailMessage(
+        email_to="dest@example.com",
+        subject="Hi",
+        html_content="<p>Hi</p>",
+    )
+
+    with caplog.at_level(logging.INFO):
+        provider.send(message)
+
+    assert sent_messages
+    sent = sent_messages[0]
+    assert sent["to"] == "dest@example.com"
+    assert sent["subject"] == "Hi"
+    assert sent["html"] == "<p>Hi</p>"
+    assert sent["smtp"]["host"] == "smtp.example.com"
+    assert sent["smtp"]["port"] == 587
+    assert sent["smtp"]["tls"] is True
+
+    assert any(
+        "Sending email via SMTP provider" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any(
+        "Email send completed" in record.getMessage() for record in caplog.records
+    )

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -45,7 +45,6 @@ function RecoverPassword() {
   const mutation = useMutation({
     mutationFn: recoverPassword,
     onSuccess: () => {
-      showSuccessToast("Password recovery email sent successfully.")
       reset()
     },
     onError: (err: ApiError) => {
@@ -54,6 +53,8 @@ function RecoverPassword() {
   })
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
+    // Optimistic UI: show success message immediately while the background task runs
+    showSuccessToast("If an account exists for that email, a recovery link will be sent.")
     mutation.mutate(data)
   }
 


### PR DESCRIPTION
Summary:
- Introduced a pluggable notifications system to send welcome and password recovery emails via a provider interface with console and SMTP options.
- Backend sends emails asynchronously using FastAPI BackgroundTasks and a dedicated notifications service.
- Configurable via environment (NOTIFICATIONS_PROVIDER) with SMTP settings; defaults to SMTP provider unless overridden.
- Removed direct email sending in business logic in favor of provider-based sending; routes schedule background tasks instead of sending inline.
- Added unit tests for providers (console and SMTP) and updated README with a new Notifications section and provider switching instructions.
- Frontend forgot-password flow now shows optimistic UI feedback while the background task runs.

What changed:
- Backend:
  - Added app/notifications with:
    - models.py: EmailMessage data model
    - providers.py: ConsoleEmailProvider and SmtpEmailProvider implementations
    - service.py: get_email_provider, send_welcome_email, and send_password_recovery_email orchestration
  - Updated app/core/config.py to include NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] with default "smtp"
  - Updated routes to use BackgroundTasks for email sending:
    - backend/app/api/routes/login.py: enqueue send_password_recovery_email
    - backend/app/api/routes/users.py: enqueue send_welcome_email on user creation
  - Refactored and removed old email sending utilities (send_email) in favor of provider-based approach
  - Tests: added backend/tests/notifications/test_providers.py with tests for Console and SMTP providers using mocks
  - Environment and docs:
    - .env: added NOTIFICATIONS_PROVIDER and related comments; default SMTP settings retained
    - README.md: added Notifications section with provider options, local example config, and how to switch providers
- Frontend:
  - frontend/src/routes/recover-password.tsx: added optimistic UI behavior by showing a toast immediately on submit while the background task runs (instead of waiting for server response)

How this solves the issue:
- Extracts email flows into a dedicated notifications layer with a provider interface, enabling easy switching between Console (development) and SMTP (production) providers.
- Uses FastAPI BackgroundTasks to avoid blocking requests when sending emails, improving responsiveness.
- Configurable via Pydantic settings and environment variables, with structured logging and error handling for better observability.
- Frontend now provides immediate optimistic feedback for forgot-password to improve user experience while the email is being sent in the background.
- Added unit tests to validate provider behavior; README now documents usage and switching between providers, aiding CI reliability.


---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/w5hy00v6pzie](https://cosine.sh/cosinedemo/full-stack-demo/task/w5hy00v6pzie)
Author: James White
