### PR TITLE
Return 409 Conflict for duplicate users with standardized error payload

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -13,6 +14,7 @@ from app.api.deps import (
 from app.core.config import settings
 from app.core.security import get_password_hash, verify_password
 from app.models import (
+    ConflictError,
     Item,
     Message,
     UpdatePassword,
@@ -27,6 +29,13 @@ from app.models import (
 from app.utils import generate_new_account_email, send_email
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+
+def conflict_response(field: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content=ConflictError(field=field, message="Already in use").model_dump(),
+    )
 
 
 @router.get(
@@ -49,7 +58,10 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
+    "/",
+    dependencies=[Depends(get_current_active_superuser)],
+    response_model=UserPublic,
+    responses={409: {"model": ConflictError}},
 )
 def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
@@ -57,10 +69,7 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system.",
-        )
+        return conflict_response("email")
 
     user = crud.create_user(session=session, user_create=user_in)
     if settings.emails_enabled and user_in.email:
@@ -75,7 +84,11 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     return user
 
 
-@router.patch("/me", response_model=UserPublic)
+@router.patch(
+    "/me",
+    response_model=UserPublic,
+    responses={409: {"model": ConflictError}},
+)
 def update_user_me(
     *, session: SessionDep, user_in: UserUpdateMe, current_user: CurrentUser
 ) -> Any:
@@ -86,9 +99,7 @@ def update_user_me(
     if user_in.email:
         existing_user = crud.get_user_by_email(session=session, email=user_in.email)
         if existing_user and existing_user.id != current_user.id:
-            raise HTTPException(
-                status_code=409, detail="User with this email already exists"
-            )
+            return conflict_response("email")
     user_data = user_in.model_dump(exclude_unset=True)
     current_user.sqlmodel_update(user_data)
     session.add(current_user)
@@ -139,17 +150,18 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
     return Message(message="User deleted successfully")
 
 
-@router.post("/signup", response_model=UserPublic)
+@router.post(
+    "/signup",
+    response_model=UserPublic,
+    responses={409: {"model": ConflictError}},
+)
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     Create new user without the need to be logged in.
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
-        )
+        return conflict_response("email")
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)
     return user
@@ -177,6 +189,7 @@ def read_user_by_id(
     "/{user_id}",
     dependencies=[Depends(get_current_active_superuser)],
     response_model=UserPublic,
+    responses={409: {"model": ConflictError}},
 )
 def update_user(
     *,
@@ -197,9 +210,7 @@ def update_user(
     if user_in.email:
         existing_user = crud.get_user_by_email(session=session, email=user_in.email)
         if existing_user and existing_user.id != user_id:
-            raise HTTPException(
-                status_code=409, detail="User with this email already exists"
-            )
+            return conflict_response("email")
 
     db_user = crud.update_user(session=session, db_user=db_user, user_in=user_in)
     return db_user

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -111,3 +111,9 @@ class TokenPayload(SQLModel):
 class NewPassword(SQLModel):
     token: str
     new_password: str = Field(min_length=8, max_length=40)
+
+
+class ConflictError(SQLModel):
+    error: str = "conflict"
+    field: str
+    message: str

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -128,8 +128,12 @@ def test_create_user_existing_username(
         json=data,
     )
     created_user = r.json()
-    assert r.status_code == 400
-    assert "_id" not in created_user
+    assert r.status_code == 409
+    assert created_user == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_create_user_by_normal_user(
@@ -260,7 +264,11 @@ def test_update_user_me_email_exists(
         json=data,
     )
     assert r.status_code == 409
-    assert r.json()["detail"] == "User with this email already exists"
+    assert r.json() == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_update_password_me_same_password_error(
@@ -316,8 +324,12 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 409
+    assert r.json() == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_update_user(
@@ -379,7 +391,11 @@ def test_update_user_email_exists(
         json=data,
     )
     assert r.status_code == 409
-    assert r.json()["detail"] == "User with this email already exists"
+    assert r.json() == {
+        "error": "conflict",
+        "field": "email",
+        "message": "Already in use",
+    }
 
 
 def test_delete_user_me(client: TestClient, db: Session) -> None:

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -7,13 +7,13 @@ import {
 import { type SubmitHandler, useForm } from "react-hook-form"
 import { FiLock, FiUser } from "react-icons/fi"
 
-import type { UserRegister } from "@/client"
+import type { ApiError, UserRegister } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Field } from "@/components/ui/field"
 import { InputGroup } from "@/components/ui/input-group"
 import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
-import { confirmPasswordRules, emailPattern, passwordRules } from "@/utils"
+import { confirmPasswordRules, emailPattern, handleError, passwordRules } from "@/utils"
 import Logo from "/assets/images/fastapi-logo.svg"
 
 export const Route = createFileRoute("/signup")({
@@ -37,8 +37,9 @@ function SignUp() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
-  } = useForm<UserRegisterForm>({
+  } =egisterForm>({
     mode: "onBlur",
     criteriaMode: "all",
     defaultValues: {
@@ -50,7 +51,20 @@ function SignUp() {
   })
 
   const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+    signUpMutation.mutate(data, {
+      onError: (err: ApiError) => {
+        const body = err.body as any
+        if (err.status === 409 && body?.error === "conflict") {
+          const field = body.field as keyof UserRegisterForm
+          setError(field, {
+            type: "server",
+            message: body.message,
+          })
+          return
+        }
+        handleError(err)
+      },
+    })
   }
 
   return (

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -95,9 +95,7 @@ test("Sign up with existing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  await expect(page.getByText("Already in use")).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {


### PR DESCRIPTION
This PR updates user-related endpoints to return a consistent 409 Conflict response when a duplicate email/username is detected, and adds a standardized error payload to be consumed by the frontend and tests. Key changes:

Backend
- Introduced ConflictError model (fields: error="conflict", field, message) and a helper conflict_response(field) that returns a 409 with the ConflictError payload.
- Updated routes (create_user, update_user_me, register_user, update_user) to return conflict_response("email") when a duplicate email is detected and to declare 409 responses with the ConflictError model for OpenAPI docs.
- Frontend-ready error shape in backend ({"error":"conflict","field":"email","message":"Already in use"}) and defensive checks integrated into the signup and user update flows.
- Tests updated to expect 409 responses with the standardized payload for all relevant duplicate scenarios.

Frontend
- Updated signup flow to map 409 Conflict errors to inline form errors. If the API returns {"error":"conflict","field":"email","message":"Already in use"}, the corresponding field shows the inline error with the provided message.
- Updated Playwright/UI tests to verify the new error message appears ("Already in use").

Docs
- OpenAPI error model documented via 409 responses referencing the ConflictError model.

Notes
- The DoD is supported by backend unit tests and Playwright tests aligned to the new error shape, and the frontend now surfaces inline validation messages for duplicate signup attempts.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/swo29lklj0yr](https://cosine.sh/cosinedemo/full-stack-demo/task/swo29lklj0yr)
Author: James White
