### PR TITLE
Add multi-tenant org support with memberships, org-scoped RBAC, and active_org_id in JWT

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -6,12 +6,12 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 from pydantic import ValidationError
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from app.core import security
 from app.core.config import settings
 from app.core.db import engine
-from app.models import TokenPayload, User
+from app.models import Membership, OrganizationRole, TokenPayload, User
 
 reusable_oauth2 = OAuth2PasswordBearer(
     tokenUrl=f"{settings.API_V1_STR}/login/access-token"
@@ -47,6 +47,51 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+def get_current_active_membership(
+    session: SessionDep, token: TokenDep, current_user: CurrentUser
+) -> Membership:
+    try:
+        payload = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[security.ALGORITHM]
+        )
+        token_data = TokenPayload(**payload)
+    except (InvalidTokenError, ValidationError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Could not validate credentials",
+        )
+
+    if not token_data.active_org_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No active organization in token",
+        )
+
+    statement = select(Membership).where(
+        Membership.org_id == token_data.active_org_id,
+        Membership.user_id == current_user.id,
+    )
+    membership = session.exec(statement).first()
+    if not membership:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not a member of the active organization",
+        )
+    return membership
+
+
+CurrentMembership = Annotated[Membership, Depends(get_current_active_membership)]
+
+
+def get_current_org_admin(membership: CurrentMembership) -> Membership:
+    if membership.role != OrganizationRole.ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The user doesn't have enough organization privileges",
+        )
+    return membership
 
 
 def get_current_active_superuser(current_user: CurrentUser) -> User:

--- a/backend/app/api/routes/items.py
+++ b/backend/app/api/routes/items.py
@@ -4,7 +4,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from sqlmodel import func, select
 
-from app.api.deps import CurrentUser, SessionDep
+from app.api.deps import CurrentMembership, CurrentUser, SessionDep
 from app.models import Item, ItemCreate, ItemPublic, ItemsPublic, ItemUpdate, Message
 
 router = APIRouter(prefix="/items", tags=["items"])
@@ -12,42 +12,56 @@ router = APIRouter(prefix="/items", tags=["items"])
 
 @router.get("/", response_model=ItemsPublic)
 def read_items(
-    session: SessionDep, current_user: CurrentUser, skip: int = 0, limit: int = 100
+    session: SessionDep,
+    current_user: CurrentUser,
+    membership: CurrentMembership,
+    skip: int = 0,
+    limit: int = 100,
 ) -> Any:
     """
-    Retrieve items.
+    Retrieve items for the active organization.
     """
 
+    count_statement = (
+        select(func.count())
+        .select_from(Item)
+        .where(Item.org_id == membership.org_id)
+    )
+    count = session.exec(count_statement).one()
     if current_user.is_superuser:
-        count_statement = select(func.count()).select_from(Item)
-        count = session.exec(count_statement).one()
-        statement = select(Item).offset(skip).limit(limit)
-        items = session.exec(statement).all()
-    else:
-        count_statement = (
-            select(func.count())
-            .select_from(Item)
-            .where(Item.owner_id == current_user.id)
-        )
-        count = session.exec(count_statement).one()
         statement = (
             select(Item)
-            .where(Item.owner_id == current_user.id)
+            .where(Item.org_id == membership.org_id)
             .offset(skip)
             .limit(limit)
         )
-        items = session.exec(statement).all()
+    else:
+        statement = (
+            select(Item)
+            .where(
+                Item.org_id == membership.org_id,
+                Item.owner_id == current_user.id,
+            )
+            .offset(skip)
+            .limit(limit)
+        )
+    items = session.exec(statement).all()
 
     return ItemsPublic(data=items, count=count)
 
 
 @router.get("/{id}", response_model=ItemPublic)
-def read_item(session: SessionDep, current_user: CurrentUser, id: uuid.UUID) -> Any:
+def read_item(
+    session: SessionDep,
+    current_user: CurrentUser,
+    membership: CurrentMembership,
+    id: uuid.UUID,
+) -> Any:
     """
-    Get item by ID.
+    Get item by ID within the active organization.
     """
     item = session.get(Item, id)
-    if not item:
+    if not item or item.org_id != membership.org_id:
         raise HTTPException(status_code=404, detail="Item not found")
     if not current_user.is_superuser and (item.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
@@ -56,12 +70,19 @@ def read_item(session: SessionDep, current_user: CurrentUser, id: uuid.UUID) -> 
 
 @router.post("/", response_model=ItemPublic)
 def create_item(
-    *, session: SessionDep, current_user: CurrentUser, item_in: ItemCreate
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    membership: CurrentMembership,
+    item_in: ItemCreate,
 ) -> Any:
     """
-    Create new item.
+    Create new item in the active organization.
     """
-    item = Item.model_validate(item_in, update={"owner_id": current_user.id})
+    item = Item.model_validate(
+        item_in,
+        update={"owner_id": current_user.id, "org_id": membership.org_id},
+    )
     session.add(item)
     session.commit()
     session.refresh(item)
@@ -73,14 +94,15 @@ def update_item(
     *,
     session: SessionDep,
     current_user: CurrentUser,
+    membership: CurrentMembership,
     id: uuid.UUID,
     item_in: ItemUpdate,
 ) -> Any:
     """
-    Update an item.
+    Update an item within the active organization.
     """
     item = session.get(Item, id)
-    if not item:
+    if not item or item.org_id != membership.org_id:
         raise HTTPException(status_code=404, detail="Item not found")
     if not current_user.is_superuser and (item.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
@@ -94,13 +116,16 @@ def update_item(
 
 @router.delete("/{id}")
 def delete_item(
-    session: SessionDep, current_user: CurrentUser, id: uuid.UUID
+    session: SessionDep,
+    current_user: CurrentUser,
+    membership: CurrentMembership,
+    id: uuid.UUID,
 ) -> Message:
     """
-    Delete an item.
+    Delete an item within the active organization.
     """
     item = session.get(Item, id)
-    if not item:
+    if not item or item.org_id != membership.org_id:
         raise HTTPException(status_code=404, detail="Item not found")
     if not current_user.is_superuser and (item.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -26,7 +26,8 @@ def login_access_token(
     session: SessionDep, form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
 ) -> Token:
     """
-    OAuth2 compatible token login, get an access token for future requests
+    OAuth2 compatible token login, get an access token for future requests.
+    The active organization is set to the first organization the user belongs to, if any.
     """
     user = crud.authenticate(
         session=session, email=form_data.username, password=form_data.password
@@ -35,10 +36,15 @@ def login_access_token(
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
+
+    active_org_id = crud.get_default_active_org_id(session=session, user_id=user.id)
+
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     return Token(
         access_token=security.create_access_token(
-            user.id, expires_delta=access_token_expires
+            user.id,
+            expires_delta=access_token_expires,
+            active_org_id=str(active_org_id) if active_org_id else None,
         )
     )
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -12,9 +12,15 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 ALGORITHM = "HS256"
 
 
-def create_access_token(subject: str | Any, expires_delta: timedelta) -> str:
+def create_access_token(
+    subject: str | Any,
+    expires_delta: timedelta,
+    active_org_id: str | None = None,
+) -> str:
     expire = datetime.now(timezone.utc) + expires_delta
-    to_encode = {"exp": expire, "sub": str(subject)}
+    to_encode: dict[str, Any] = {"exp": expire, "sub": str(subject)}
+    if active_org_id is not None:
+        to_encode["active_org_id"] = active_org_id
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -4,7 +4,16 @@ from typing import Any
 from sqlmodel import Session, select
 
 from app.core.security import get_password_hash, verify_password
-from app.models import Item, ItemCreate, User, UserCreate, UserUpdate
+from app.models import (
+    Item,
+    ItemCreate,
+    Membership,
+    Organization,
+    OrganizationRole,
+    User,
+    UserCreate,
+    UserUpdate,
+)
 
 
 def create_user(*, session: Session, user_create: UserCreate) -> User:
@@ -46,9 +55,46 @@ def authenticate(*, session: Session, email: str, password: str) -> User | None:
     return db_user
 
 
-def create_item(*, session: Session, item_in: ItemCreate, owner_id: uuid.UUID) -> Item:
-    db_item = Item.model_validate(item_in, update={"owner_id": owner_id})
+def create_item(
+    *,
+    session: Session,
+    item_in: ItemCreate,
+    owner_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> Item:
+    db_item = Item.model_validate(
+        item_in, update={"owner_id": owner_id, "org_id": org_id}
+    )
     session.add(db_item)
     session.commit()
     session.refresh(db_item)
     return db_item
+
+
+def create_organization(
+    *, session: Session, owner_id: uuid.UUID, name: str
+) -> Organization:
+    organization = Organization(name=name, owner_id=owner_id)
+    session.add(organization)
+    session.commit()
+    session.refresh(organization)
+
+    membership = Membership(
+        user_id=owner_id, org_id=organization.id, role=OrganizationRole.ADMIN
+    )
+    session.add(membership)
+    session.commit()
+
+    return organization
+
+
+def get_default_active_org_id(*, session: Session, user_id: uuid.UUID) -> uuid.UUID | None:
+    statement = (
+        select(Membership)
+        .where(Membership.user_id == user_id)
+        .order_by(Membership.role == OrganizationRole.ADMIN)
+    )
+    membership = session.exec(statement).first()
+    if membership:
+        return membership.org_id
+    return None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,13 @@
 import uuid
+from enum import Enum
 
 from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
+
+
+class OrganizationRole(str, Enum):
+    ADMIN = "admin"
+    MEMBER = "member"
 
 
 # Shared properties
@@ -44,6 +50,12 @@ class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str
     items: list["Item"] = Relationship(back_populates="owner", cascade_delete=True)
+    memberships: list["Membership"] = Relationship(
+        back_populates="user", cascade_delete=True
+    )
+    owned_organizations: list["Organization"] = Relationship(
+        back_populates="owner", cascade_delete=True
+    )
 
 
 # Properties to return via API, id is always required
@@ -54,6 +66,68 @@ class UserPublic(UserBase):
 class UsersPublic(SQLModel):
     data: list[UserPublic]
     count: int
+
+
+class OrganizationBase(SQLModel):
+    name: str = Field(min_length=1, max_length=255)
+
+
+class OrganizationCreate(OrganizationBase):
+    pass
+
+
+class OrganizationUpdate(OrganizationBase):
+    name: str | None = Field(default=None, min_length=1, max_length=255)  # type: ignore
+
+
+class Organization(OrganizationBase, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    owner_id: uuid.UUID = Field(
+        foreign_key="user.id", nullable=False, ondelete="CASCADE"
+    )
+
+    owner: User | None = Relationship(back_populates="owned_organizations")
+    memberships: list["Membership"] = Relationship(
+        back_populates="organization", cascade_delete=True
+    )
+    items: list["Item"] = Relationship(
+        back_populates="organization", cascade_delete=True
+    )
+
+
+class OrganizationPublic(OrganizationBase):
+    id: uuid.UUID
+    owner_id: uuid.UUID
+
+
+class OrganizationsPublic(SQLModel):
+    data: list[OrganizationPublic]
+    count: int
+
+
+class MembershipBase(SQLModel):
+    role: OrganizationRole = Field(default=OrganizationRole.MEMBER)
+
+
+class MembershipCreate(MembershipBase):
+    user_id: uuid.UUID | None = None
+
+
+class MembershipUpdate(MembershipBase):
+    role: OrganizationRole | None = None
+
+
+class Membership(MembershipBase, table=True):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_id: uuid.UUID = Field(
+        foreign_key="user.id", nullable=False, ondelete="CASCADE"
+    )
+    org_id: uuid.UUID = Field(
+        foreign_key="organization.id", nullable=False, ondelete="CASCADE"
+    )
+
+    user: User | None = Relationship(back_populates="memberships")
+    organization: Organization | None = Relationship(back_populates="memberships")
 
 
 # Shared properties
@@ -75,15 +149,21 @@ class ItemUpdate(ItemBase):
 # Database model, database table inferred from class name
 class Item(ItemBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    org_id: uuid.UUID = Field(
+        foreign_key="organization.id", nullable=False, ondelete="CASCADE"
+    )
     owner_id: uuid.UUID = Field(
         foreign_key="user.id", nullable=False, ondelete="CASCADE"
     )
+
+    organization: Organization | None = Relationship(back_populates="items")
     owner: User | None = Relationship(back_populates="items")
 
 
 # Properties to return via API, id is always required
 class ItemPublic(ItemBase):
     id: uuid.UUID
+    org_id: uuid.UUID
     owner_id: uuid.UUID
 
 
@@ -106,6 +186,7 @@ class Token(SQLModel):
 # Contents of JWT token
 class TokenPayload(SQLModel):
     sub: str | None = None
+    active_org_id: str | None = None
 
 
 class NewPassword(SQLModel):


### PR DESCRIPTION
This PR introduces multi-tenant organization support and RBAC, with org-scoped data access and a JWT that carries the active organization.

What changed
- Models
  - Added Organization, Membership, and OrganizationRole (ADMIN, MEMBER).
  - Item now stores org_id and relates to Organization; User now has memberships and owned_organizations relationships.
  - TokenPayload extended with active_org_id to carry the currently active organization in the JWT.
- RBAC and scope enforcement
  - Implemented current membership resolution by decoding the JWT’s active_org_id and validating the user’s membership for that org.
  - Added admin check helper to enforce admin privileges for org-level actions (e.g., invites/removals to be enabled in future endpoints).
  - Item routes are now fully scoped to the active organization: reads/writes are filtered by org_id, and ownership checks respect org scope.
- API routing and dependencies
  - New dependency CurrentMembership to ensure requests are performed within the user’s active organization.
  - Endpoints updated in items router to require membership and restrict item operations to the active org.
- Core/auth enhancements
  - login now determines a default active_org_id (first org the user belongs to) and includes it in the generated JWT as active_org_id.
  - Security layer updated to encode active_org_id in JWT and verify it on requests.
- CRUD helpers
  - Added create_organization to bootstrap a new org and seed an admin membership for the creator.
  - Added get_default_active_org_id to select a default active organization for a user when logging in.
- API surface adjustments
  - Item creation now assigns both owner_id and org_id from the membership context; updates enforce org scope; reads are constrained by org_id.
  - Item read by id validates the item belongs to the active organization before returning data.

This set of changes enables multi-tenant usage where data is isolated by organization, enforces basic RBAC within organizations, and ensures all reads/writes are scoped to the active org. The JWT now carries active_org_id to persist and enforce the current org across requests.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/fyhgqubxerw9](https://cosine.sh/cosinedemo/full-stack-demo/task/fyhgqubxerw9)
Author: James White
