### PR TITLE
Add pluggable notification system with async email sending and provider-based config; integrate into password recovery and welcome flows; update frontend loading state and docs/tests

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,11 @@ SMTP_TLS=True
 SMTP_SSL=False
 SMTP_PORT=587
 
+# Notifications
+# console: log email notifications to the backend logs (useful for local dev)
+# smtp: send real emails via SMTP using the configuration above
+NOTIFICATIONS_PROVIDER=console
+
 # Postgres
 POSTGRES_SERVER=localhost
 POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -216,6 +216,26 @@ The input variables, with their default values (some auto generated) are:
 
 Backend docs: [backend/README.md](./backend/README.md).
 
+## Notifications
+
+Email notifications (welcome emails, password recovery) are handled through a pluggable notifications system.
+
+- Providers live under `backend/app/notifications/`.
+- The active provider is selected via the `NOTIFICATIONS_PROVIDER` setting:
+  - `console`: log email payloads to the backend logs (recommended for local development).
+  - `smtp`: send real emails via SMTP using the `SMTP_*` and `EMAILS_FROM_EMAIL` settings in `.env`.
+
+To switch between providers, set the environment variable in your `.env`:
+
+```env
+NOTIFICATIONS_PROVIDER=console  # or "smtp"
+```
+
+The flows for:
+
+- **Welcome emails** are triggered when an admin creates a new user.
+- **Password recovery** is triggered from the "Forgot password" screen and sent asynchronously with FastAPI `BackgroundTasks`.
+
 ## Frontend Development
 
 Frontend docs: [frontend/README.md](./frontend/README.md).

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -11,10 +11,10 @@ from app.core import security
 from app.core.config import settings
 from app.core.security import get_password_hash
 from app.models import Message, NewPassword, Token, UserPublic
+from app.notifications.service import send_password_recovery_email
 from app.utils import (
     generate_password_reset_token,
     generate_reset_password_email,
-    send_email,
     verify_password_reset_token,
 )
 
@@ -52,9 +52,14 @@ def test_token(current_user: CurrentUser) -> Any:
 
 
 @router.post("/password-recovery/{email}")
-def recover_password(email: str, session: SessionDep) -> Message:
+def recover_password(
+    email: str,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+) -> Message:
     """
-    Password Recovery
+    Password Recovery.
+    The email is sent asynchronously using FastAPI BackgroundTasks.
     """
     user = crud.get_user_by_email(session=session, email=email)
 
@@ -64,13 +69,11 @@ def recover_password(email: str, session: SessionDep) -> Message:
             detail="The user with this email does not exist in the system.",
         )
     password_reset_token = generate_password_reset_token(email=email)
-    email_data = generate_reset_password_email(
-        email_to=user.email, email=email, token=password_reset_token
-    )
-    send_email(
+    send_password_recovery_email(
         email_to=user.email,
-        subject=email_data.subject,
-        html_content=email_data.html_content,
+        email=email,
+        token=password_reset_token,
+        background_tasks=background_tasks,
     )
     return Message(message="Password recovery email sent")
 

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -24,7 +24,7 @@ from app.models import (
     UserUpdate,
     UserUpdateMe,
 )
-from app.utils import generate_new_account_email, send_email
+from app.notifications.service import send_welcome_email
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -51,7 +51,12 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(
+    *,
+    session: SessionDep,
+    user_in: UserCreate,
+    background_tasks: BackgroundTasks,
+) -> Any:
     """
     Create new user.
     """
@@ -63,14 +68,12 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
         )
 
     user = crud.create_user(session=session, user_create=user_in)
-    if settings.emails_enabled and user_in.email:
-        email_data = generate_new_account_email(
-            email_to=user_in.email, username=user_in.email, password=user_in.password
-        )
-        send_email(
+    if user_in.email:
+        send_welcome_email(
             email_to=user_in.email,
-            subject=email_data.subject,
-            html_content=email_data.html_content,
+            username=user_in.email,
+            password=user_in.password,
+            background_tasks=background_tasks,
         )
     return user
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -94,6 +94,11 @@ class Settings(BaseSettings):
     FIRST_SUPERUSER: EmailStr
     FIRST_SUPERUSER_PASSWORD: str
 
+    # Notifications
+    # console: log emails to console (useful for local dev)
+    # smtp: send real emails via SMTP configuration
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "console"
+
     def _check_default_secret(self, var_name: str, value: str | None) -> None:
         if value == "changethis":
             message = (

--- a/backend/app/notifications/__init__.py
+++ b/backend/app/notifications/__init__.py
@@ -1,0 +1,3 @@
+from .base import NotificationProvider, get_notification_provider
+
+__all__ = ["NotificationProvider", "get_notification_provider"]

--- a/backend/app/notifications/base.py
+++ b/backend/app/notifications/base.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Protocol, runtime_checkable
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class NotificationProvider(Protocol):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:  # pragma: no cover - Protocol
+        ...
+
+
+def get_notification_provider() -> NotificationProvider:
+    """
+    Return the configured notification provider based on settings.
+
+    The provider is selected via settings.NOTIFICATIONS_PROVIDER.
+    """
+    from app.notifications.providers import ConsoleNotificationProvider, SMTPNotificationProvider
+
+    provider_name = settings.NOTIFICATIONS_PROVIDER
+
+    if provider_name == "console":
+        logger.info("Using ConsoleNotificationProvider for notifications")
+        return ConsoleNotificationProvider()
+
+    if provider_name == "smtp":
+        logger.info("Using SMTPNotificationProvider for notifications")
+        return SMTPNotificationProvider()
+
+    logger.warning(
+        "Unknown NOTIFICATIONS_PROVIDER '%s', falling back to ConsoleNotificationProvider",
+        provider_name,
+    )
+    return ConsoleNotificationProvider()

--- a/backend/app/notifications/exceptions.py
+++ b/backend/app/notifications/exceptions.py
@@ -1,0 +1,2 @@
+class NotificationError(Exception):
+    """Raised when a notification cannot be sent."""

--- a/backend/app/notifications/providers.py
+++ b/backend/app/notifications/providers.py
@@ -1,0 +1,96 @@
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import emails  # type: ignore
+
+from app.core.config import settings
+from app.notifications.exceptions import NotificationError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SMTPConfig:
+    host: str
+    port: int
+    tls: bool
+    ssl: bool
+    user: str | None
+    password: str | None
+    from_name: str
+    from_email: str
+
+
+class ConsoleNotificationProvider:
+    """
+    Notification provider that logs emails to the console.
+
+    Useful for local development and testing without an SMTP server.
+    """
+
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        payload: dict[str, Any] = {
+            "provider": "console",
+            "email_to": email_to,
+            "subject": subject,
+            "html_length": len(html_content),
+        }
+        logger.info("notification_email_console", extra=payload)
+
+
+class SMTPNotificationProvider:
+    """
+    Notification provider that sends emails via SMTP using the `emails` library.
+    """
+
+    def __init__(self) -> None:
+        if not settings.emails_enabled:
+            raise NotificationError("SMTPNotificationProvider requires email settings")
+
+        if not settings.SMTP_HOST:
+            raise NotificationError("SMTP_HOST must be set for SMTPNotificationProvider")
+
+        self.config = _SMTPConfig(
+            host=settings.SMTP_HOST,
+            port=settings.SMTP_PORT,
+            tls=settings.SMTP_TLS,
+            ssl=settings.SMTP_SSL,
+            user=settings.SMTP_USER,
+            password=settings.SMTP_PASSWORD,
+            from_name=str(settings.EMAILS_FROM_NAME),
+            from_email=str(settings.EMAILS_FROM_EMAIL),
+        )
+
+    def _smtp_options(self) -> dict[str, Any]:
+        options: dict[str, Any] = {"host": self.config.host, "port": self.config.port}
+        if self.config.tls:
+            options["tls"] = True
+        elif self.config.ssl:
+            options["ssl"] = True
+        if self.config.user:
+            options["user"] = self.config.user
+        if self.config.password:
+            options["password"] = self.config.password
+        return options
+
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        payload: dict[str, Any] = {
+            "provider": "smtp",
+            "email_to": email_to,
+            "subject": subject,
+            "html_length": len(html_content),
+            "smtp_host": self.config.host,
+            "smtp_port": self.config.port,
+        }
+        try:
+            message = emails.Message(
+                subject=subject,
+                html=html_content,
+                mail_from=(self.config.from_name, self.config.from_email),
+            )
+            response = message.send(to=email_to, smtp=self._smtp_options())
+            logger.info("notification_email_smtp_success", extra={**payload, "response": str(response)})
+        except Exception as exc:  # pragma: no cover - error path
+            logger.error("notification_email_smtp_error", extra={**payload, "error": repr(exc)})
+            raise NotificationError("Error sending email via SMTP") from exc

--- a/backend/app/notifications/service.py
+++ b/backend/app/notifications/service.py
@@ -1,0 +1,62 @@
+from fastapi import BackgroundTasks
+
+from app.notifications import get_notification_provider
+from app.utils import generate_new_account_email, generate_reset_password_email
+
+_provider = get_notification_provider()
+
+
+def send_welcome_email(
+    *,
+    email_to: str,
+    username: str,
+    password: str,
+    background_tasks: BackgroundTasks | None = None,
+) -> None:
+    email_data = generate_new_account_email(
+        email_to=email_to,
+        username=username,
+        password=password,
+    )
+
+    if background_tasks is not None:
+        background_tasks.add_task(
+            _provider.send_email,
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+    else:  # pragma: no cover - used only when called without BackgroundTasks
+        _provider.send_email(
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+
+
+def send_password_recovery_email(
+    *,
+    email_to: str,
+    email: str,
+    token: str,
+    background_tasks: BackgroundTasks | None = None,
+) -> None:
+    email_data = generate_reset_password_email(
+        email_to=email_to,
+        email=email,
+        token=token,
+    )
+
+    if background_tasks is not None:
+        background_tasks.add_task(
+            _provider.send_email,
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+    else:  # pragma: no cover - used only when called without BackgroundTasks
+        _provider.send_email(
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )

--- a/backend/tests/notifications/test_providers.py
+++ b/backend/tests/notifications/test_providers.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.notifications.base import get_notification_provider
+from app.notifications.exceptions import NotificationError
+from app.notifications.providers import ConsoleNotificationProvider, SMTPNotificationProvider
+
+
+def test_console_provider_logs_without_error(caplog) -> None:
+    provider = ConsoleNotificationProvider()
+
+    with caplog.at_level("INFO"):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test",
+            html_content="<p>Test</p>",
+        )
+
+    assert any("notification_email_console" in record.message for record in caplog.records)
+
+
+def test_smtp_provider_builds_smtp_options(monkeypatch) -> None:
+    # Configure settings for SMTP provider
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+    monkeypatch.setenv("SMTP_USER", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pass")
+    monkeypatch.setenv("EMAILS_FROM_EMAIL", "from@example.com")
+
+    provider = SMTPNotificationProvider()
+
+    with patch("emails.Message") as message_cls:
+        instance = MagicMock()
+        message_cls.return_value = instance
+
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Subject",
+            html_content="<p>Body</p>",
+        )
+
+        instance.send.assert_called_once()
+        args, kwargs = instance.send.call_args
+        assert kwargs["to"] == "user@example.com"
+        smtp_options = kwargs["smtp"]
+        assert smtp_options["host"] == "smtp.example.com"
+        assert smtp_options["port"] == 2525
+
+
+def test_get_notification_provider_console(monkeypatch) -> None:
+    monkeypatch.setenv("NOTIFICATIONS_PROVIDER", "console")
+    provider = get_notification_provider()
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+
+def test_get_notification_provider_smtp_requires_config(monkeypatch) -> None:
+    monkeypatch.setenv("NOTIFICATIONS_PROVIDER", "smtp")
+    # Ensure missing configuration triggers NotificationError on provider init
+    with pytest.raises(NotificationError):
+        SMTPNotificationProvider()

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -32,7 +32,7 @@ function RecoverPassword() {
     register,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm<FormData>()
   const { showSuccessToast } = useCustomToast()
 
@@ -86,7 +86,12 @@ function RecoverPassword() {
           />
         </InputGroup>
       </Field>
-      <Button variant="solid" type="submit" loading={isSubmitting}>
+      <Button
+        variant="solid"
+        type="submit"
+        loading={mutation.isPending}
+        loadingText="Sending email..."
+      >
         Continue
       </Button>
     </Container>


### PR DESCRIPTION
Summary:
- Introduced a pluggable notification system with a provider interface (Console and SMTP) for email notifications (welcome, password recovery).
- Backend sends emails asynchronously using FastAPI BackgroundTasks and a centralized notifications service.
- Configured via Pydantic settings with NOTIFICATIONS_PROVIDER switch (console or smtp).
- Added unit tests for providers, and README/.env documentation for notifications.
- Frontend improved user feedback by showing loading state during password recovery request.

What changed in the backend:
- New notifications package under backend/app/notifications:
  - base.py: Defines NotificationProvider protocol and get_notification_provider() to select provider based on settings.
  - providers.py: Implementations for ConsoleNotificationProvider (logs payloads) and SMTPNotificationProvider (sends real emails via the emails library); includes error handling and environment-driven config validation.
  - service.py: Exposes send_welcome_email and send_password_recovery_email, which use the configured provider and support FastAPI BackgroundTasks for asynchronous sending.
  - exceptions.py: NotificationError for provider-related failures.
  - __init__.py: Re-exports for easier imports.
- Settings: backend/app/core/config.py adds NOTIFICATIONS_PROVIDER with allowed values console or smtp and defaults to console.
- Route changes:
  - backend/app/api/routes/login.py: recover_password() now accepts BackgroundTasks and delegates email sending to the notification service, enabling async delivery.
  - backend/app/api/routes/users.py: create_user() updated to accept BackgroundTasks and trigger a welcome email via the notification service when a new user has an email.
- Tests: backend/tests/notifications/test_providers.py verifies Console and SMTP provider behavior, provider selection, and error on missing config for SMTP.

What changed in the documentation and environment:
- .env: Added NOTIFICATIONS_PROVIDER=console (default) with comments explaining available providers (console, smtp).
- README.md: Added a new Notifications section describing providers, how to switch via NOTIFICATIONS_PROVIDER, and which flows are affected (welcome emails on admin-created users, password recovery via Forgot Password screen with async sending).

Frontend changes:
- frontend/src/routes/recover-password.tsx: Button shows loading state based on mutation.isPending with a loadingText, improving UX during the async password recovery email send.

How to use:
- By default, NOTIFICATIONS_PROVIDER is set to console for local development. To enable real emails, configure SMTP settings (SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, EMAILS_FROM_EMAIL, etc.) and set NOTIFICATIONS_PROVIDER=smtp in your .env.
- Password recovery and welcome flows will send emails asynchronously using FastAPI BackgroundTasks, with errors logged and a clear provider-based behavior.

Testing and CI:
- Added unit tests for both notification providers and provider selection to ensure correct behavior and error handling.
- CI should pass with the new tests and documentation in place.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/cke1jmbrtejd](https://cosine.sh/cosinedemo/full-stack-demo/task/cke1jmbrtejd)
Author: James White
