### PR TITLE
Add pluggable notifications with background sending (console/SMTP), config, tests, and frontend optimistic UI

### DIFF
--- a/.env
+++ b/.env
@@ -30,6 +30,8 @@ EMAILS_FROM_EMAIL=info@example.com
 SMTP_TLS=True
 SMTP_SSL=False
 SMTP_PORT=587
+# Notifications provider: "console" (default) or "smtp"
+NOTIFICATIONS_PROVIDER=console
 
 # Postgres
 POSTGRES_SERVER=localhost

--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ Read the [deployment.md](./deployment.md) docs for more details.
 
 Some environment variables in the `.env` file have a default value of `changethis`.
 
+### Notifications
+
+Email notifications (welcome emails, password recovery, and test emails) are sent through a pluggable notifications provider.
+
+The provider is configured in the root `.env` file with:
+
+- `NOTIFICATIONS_PROVIDER=console` (default): logs email payloads to the backend logs, useful for local development.
+- `NOTIFICATIONS_PROVIDER=smtp`: sends real emails using the SMTP settings (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `EMAILS_FROM_EMAIL`, etc.).
+
+To switch providers:
+
+1. Update the `NOTIFICATIONS_PROVIDER` value in your `.env` file.
+2. Ensure the corresponding settings are configured (for example, SMTP details when using `smtp`).
+3. Restart the backend so the new configuration is picked up.
+
 You have to change them with a secret key, to generate secret keys you can run the following command:
 
 ```bash

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -52,9 +52,15 @@ def test_token(current_user: CurrentUser) -> Any:
 
 
 @router.post("/password-recovery/{email}")
-def recover_password(email: str, session: SessionDep) -> Message:
+def recover_password(
+    email: str,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+) -> Message:
     """
     Password Recovery
+
+    The email is sent in a background task so the API can respond quickly.
     """
     user = crud.get_user_by_email(session=session, email=email)
 
@@ -67,7 +73,8 @@ def recover_password(email: str, session: SessionDep) -> Message:
     email_data = generate_reset_password_email(
         email_to=user.email, email=email, token=password_reset_token
     )
-    send_email(
+    background_tasks.add_task(
+        send_email,
         email_to=user.email,
         subject=email_data.subject,
         html_content=email_data.html_content,

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -51,7 +51,12 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(
+    *,
+    session: SessionDep,
+    user_in: UserCreate,
+    background_tasks: BackgroundTasks,
+) -> Any:
     """
     Create new user.
     """
@@ -67,7 +72,8 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
         email_data = generate_new_account_email(
             email_to=user_in.email, username=user_in.email, password=user_in.password
         )
-        send_email(
+        background_tasks.add_task(
+            send_email,
             email_to=user_in.email,
             subject=email_data.subject,
             html_content=email_data.html_content,

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 from pydantic.networks import EmailStr
 
 from app.api.deps import get_current_active_superuser
@@ -13,12 +13,15 @@ router = APIRouter(prefix="/utils", tags=["utils"])
     dependencies=[Depends(get_current_active_superuser)],
     status_code=201,
 )
-def test_email(email_to: EmailStr) -> Message:
+def test_email(email_to: EmailStr, background_tasks: BackgroundTasks) -> Message:
     """
     Test emails.
+
+    The email is sent in a background task so the API can respond quickly.
     """
     email_data = generate_test_email(email_to=email_to)
-    send_email(
+    background_tasks.add_task(
+        send_email,
         email_to=email_to,
         subject=email_data.subject,
         html_content=email_data.html_content,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str | None = None
     EMAILS_FROM_EMAIL: EmailStr | None = None
     EMAILS_FROM_NAME: EmailStr | None = None
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "console"
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:

--- a/backend/app/notifications/__init__.py
+++ b/backend/app/notifications/__init__.py
@@ -1,0 +1,15 @@
+from .providers import (
+    BaseNotificationProvider,
+    ConsoleNotificationProvider,
+    NotificationSendError,
+    SmtpNotificationProvider,
+    get_provider,
+)
+
+__all__ = [
+    "BaseNotificationProvider",
+    "ConsoleNotificationProvider",
+    "SmtpNotificationProvider",
+    "NotificationSendError",
+    "get_provider",
+]

--- a/backend/app/notifications/providers.py
+++ b/backend/app/notifications/providers.py
@@ -1,0 +1,90 @@
+import logging
+from abc import ABC, abstractmethod
+
+import emails  # type: ignore
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationSendError(RuntimeError):
+    """Raised when sending a notification fails."""
+
+
+class BaseNotificationProvider(ABC):
+    @abstractmethod
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        raise NotImplementedError
+
+
+class ConsoleNotificationProvider(BaseNotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            {
+                "event": "notification.send.console",
+                "status": "success",
+                "provider": "console",
+                "email_to": email_to,
+                "subject": subject,
+                "html_length": len(html_content),
+            }
+        )
+
+
+class SmtpNotificationProvider(BaseNotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        if not settings.emails_enabled:
+            raise NotificationSendError("Email settings are not configured")
+
+        message = emails.Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        try:
+            response = message.send(to=email_to, smtp=smtp_options)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "Error sending email with SMTP provider",
+                extra={
+                    "event": "notification.send.smtp",
+                    "status": "error",
+                    "provider": "smtp",
+                    "email_to": email_to,
+                    "subject": subject,
+                },
+            )
+            raise NotificationSendError("Error sending email via SMTP") from exc
+
+        logger.info(
+            {
+                "event": "notification.send.smtp",
+                "status": "success",
+                "provider": "smtp",
+                "email_to": email_to,
+                "subject": subject,
+                "response": str(response),
+            }
+        )
+
+
+def get_provider() -> BaseNotificationProvider:
+    provider_name = settings.NOTIFICATIONS_PROVIDER
+    if provider_name == "console":
+        return ConsoleNotificationProvider()
+    if provider_name == "smtp":
+        return SmtpNotificationProvider()
+    raise ValueError(f"Unsupported notifications provider: {provider_name}")

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import NotificationSendError, get_provider
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,23 +36,43 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
-        subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
-    )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
+    """
+    Send an email using the configured notification provider.
+
+    This keeps a stable API for existing callers while delegating the actual
+    delivery to a provider implementation.
+    """
+    provider = get_provider()
+    try:
+        provider.send_email(
+            email_to=email_to,
+            subject=subject,
+            html_content=html_content,
+        )
+        logger.info(
+            {
+                "event": "notification.send",
+                "status": "success",
+                "provider": type(provider).__name__,
+                "email_to": email_to,
+                "subject": subject,
+            }
+        )
+    except NotificationSendError:
+        # Provider already logged a structured error, just re-raise.
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "Unexpected error sending notification",
+            extra={
+                "event": "notification.send",
+                "status": "error",
+                "provider": type(provider).__name__,
+                "email_to": email_to,
+                "subject": subject,
+            },
+        )
+        raise NotificationSendError("Unexpected error sending notification") from exc
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/notifications/test_providers.py
+++ b/backend/tests/notifications/test_providers.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.notifications import (
+    ConsoleNotificationProvider,
+    NotificationSendError,
+    SmtpNotificationProvider,
+    get_provider,
+)
+
+
+def test_console_provider_logs(caplog: pytest.LogCaptureFixture) -> None:
+    provider = ConsoleNotificationProvider()
+    with caplog.at_level("INFO"):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test",
+            html_content="<p>Hi</p>",
+        )
+    assert any("notification.send.console" in str(record.msg) for record in caplog.records)
+
+
+def test_smtp_provider_uses_emails_library() -> None:
+    provider = SmtpNotificationProvider()
+    with (
+        patch("app.notifications.providers.emails.Message") as message_cls,
+        patch.object(settings, "emails_enabled", True),
+    ):
+        message_instance = MagicMock()
+        message_cls.return_value = message_instance
+
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test",
+            html_content="<p>Hi</p>",
+        )
+
+        message_cls.assert_called_once()
+        message_instance.send.assert_called_once()
+
+
+def test_smtp_provider_raises_on_error() -> None:
+    provider = SmtpNotificationProvider()
+    with (
+        patch("app.notifications.providers.emails.Message") as message_cls,
+        patch.object(settings, "emails_enabled", True),
+    ):
+        message_instance = MagicMock()
+        message_instance.send.side_effect = RuntimeError("smtp error")
+        message_cls.return_value = message_instance
+
+        with pytest.raises(NotificationSendError):
+            provider.send_email(
+                email_to="user@example.com",
+                subject="Test",
+                html_content="<p>Hi</p>",
+            )
+
+
+def test_get_provider_console() -> None:
+    with patch.object(settings, "NOTIFICATIONS_PROVIDER", "console"):
+        provider = get_provider()
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+
+def test_get_provider_smtp() -> None:
+    with patch.object(settings, "NOTIFICATIONS_PROVIDER", "smtp"):
+        provider = get_provider()
+    assert isinstance(provider, SmtpNotificationProvider)

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -32,7 +32,7 @@ function RecoverPassword() {
     register,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm<FormData>()
   const { showSuccessToast } = useCustomToast()
 
@@ -45,7 +45,7 @@ function RecoverPassword() {
   const mutation = useMutation({
     mutationFn: recoverPassword,
     onSuccess: () => {
-      showSuccessToast("Password recovery email sent successfully.")
+      showSuccessToast("If an account exists for that email, a recovery link was sent.")
       reset()
     },
     onError: (err: ApiError) => {
@@ -83,10 +83,16 @@ function RecoverPassword() {
             })}
             placeholder="Email"
             type="email"
+            isDisabled={mutation.isPending}
           />
         </InputGroup>
       </Field>
-      <Button variant="solid" type="submit" loading={isSubmitting}>
+      <Button
+        variant="solid"
+        type="submit"
+        loading={mutation.isPending}
+        isDisabled={mutation.isPending}
+      >
         Continue
       </Button>
     </Container>


### PR DESCRIPTION
Summary:
- Introduced a pluggable notifications system with a provider interface and two providers: Console (default) and SMTP.
- Backend sends emails asynchronously using FastAPI BackgroundTasks to avoid blocking API responses.
- Configurable via environment variable NOTIFICATIONS_PROVIDER and standard SMTP settings; integrated into the existing settings scaffold.
- Centralized email sending through a provider, with structured logging and error handling.
- Updated endpoints to use background tasks for sending emails (password recovery, new account). Added tests for providers and provider selection.
- Frontend improvement: forgot password flow shows optimistic UI text and disables input while the background task runs.
- Documentation and examples: .env entry, README section for Notifications, and tests for providers.

What changed:
- backend/app/notifications (new)
  - __init__.py and providers.py implement:
    - BaseNotificationProvider, ConsoleNotificationProvider, SmtpNotificationProvider
    - NotificationSendError exception
    - get_provider() selecting provider based on settings
  - Structured logging for both providers and error paths
- backend/app/core/config.py
  - Added NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "console"
- backend/app/utils.py
  - send_email now delegates to the selected provider via get_provider()
  - Added logging around provider-based sending and re-raised NotificationSendError on failure
- backend/app/api/routes/password-recovery.py (login.py) and backend/app/api/routes/users.py
  - Import BackgroundTasks and use background_tasks.add_task(send_email, ...)
  - Password recovery and user creation now send emails asynchronously
- backend/tests/notifications/test_providers.py (new)
  - Tests for Console and SMTP providers and provider retrieval
- backend/app/README, .env, and docs updates
  - .env: add NOTIFICATIONS_PROVIDER=console
  - README: section “Notifications” explaining providers, usage, and how to switch
  - Frontend: recover-password.tsx updated to show optimistic UI text and proper disabled state during pending
- frontend changes
  - forgot password: onSuccess message changed to a non-blocking optimistic UI message; input disabled while pending

How this solves the task:
- Encapsulates email sending behind a provider interface, enabling easy switching between console logging (dev) and SMTP (prod) without code changes.
- Uses BackgroundTasks to perform email sending asynchronously, keeping API responses fast and improving UX for password recovery and account creation.
- Provides configuration via .env and Settings (typed with Pydantic) to enable simple, centralized control of notification behavior.
- Adds unit tests to validate provider behavior and provider switching, ensuring reliability and easier maintenance.
- Updates frontend to reflect background operation with optimistic messaging, improving user experience during background email delivery.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/4wo08kw0v3s1](https://cosine.sh/cosinedemo/full-stack-demo/task/4wo08kw0v3s1)
Author: James White
