### PR TITLE
Add pluggable email notifications with providers (console, SMTP) and background task sending

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,10 @@ SECRET_KEY=changethis
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
 
-# Emails
+# Emails / notifications
+# Use NOTIFICATIONS_PROVIDER=console for local development without SMTP,
+# or NOTIFICATIONS_PROVIDER=smtp to send real emails via SMTP.
+NOTIFICATIONS_PROVIDER=console
 SMTP_HOST=
 SMTP_USER=
 SMTP_PASSWORD=

--- a/backend/README.md
+++ b/backend/README.md
@@ -170,3 +170,49 @@ The email templates are in `./backend/app/email-templates/`. Here, there are two
 Before continuing, ensure you have the [MJML extension](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml) installed in your VS Code.
 
 Once you have the MJML extension installed, you can create a new email template in the `src` directory. After creating the new email template and with the `.mjml` file open in your editor, open the command palette with `Ctrl+Shift+P` and search for `MJML: Export to HTML`. This will convert the `.mjml` file to a `.html` file and now you can save it in the build directory.
+
+## Notifications
+
+Email notifications (welcome, password recovery and test emails) are handled via the `app.notifications` package.
+
+### Providers
+
+Notifications use a provider interface so you can switch how emails are sent without changing application code.
+
+There are two built-in providers:
+
+- `console`: logs email subject and content, useful for local development.
+- `smtp`: sends real emails using the SMTP configuration from the environment.
+
+The provider is selected with the `NOTIFICATIONS_PROVIDER` environment variable (see `.env`):
+
+- `NOTIFICATIONS_PROVIDER=console` – default for local development, no SMTP required.
+- `NOTIFICATIONS_PROVIDER=smtp` – use SMTP to send real emails.
+
+### Configuration
+
+The following settings in `.env` are used:
+
+```env
+NOTIFICATIONS_PROVIDER=console  # or smtp
+
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_TLS=True
+SMTP_SSL=False
+SMTP_USER=
+SMTP_PASSWORD=
+EMAILS_FROM_EMAIL=info@example.com
+```
+
+When using the `smtp` provider, make sure `SMTP_HOST` and `EMAILS_FROM_EMAIL` are set; otherwise, emails will effectively be disabled.
+
+### Flows
+
+The main notification flows are:
+
+- Welcome email on user creation (admin API).
+- Password recovery email.
+- Test email endpoint for verifying configuration.
+
+All email sending is scheduled using FastAPI `BackgroundTasks`, so the API responses return quickly while the email is sent in the background.

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.security import OAuth2PasswordRequestForm
 
@@ -11,10 +11,9 @@ from app.core import security
 from app.core.config import settings
 from app.core.security import get_password_hash
 from app.models import Message, NewPassword, Token, UserPublic
+from app.notifications import send_password_recovery_email
 from app.utils import (
     generate_password_reset_token,
-    generate_reset_password_email,
-    send_email,
     verify_password_reset_token,
 )
 
@@ -52,7 +51,11 @@ def test_token(current_user: CurrentUser) -> Any:
 
 
 @router.post("/password-recovery/{email}")
-def recover_password(email: str, session: SessionDep) -> Message:
+def recover_password(
+    email: str,
+    session: SessionDep,
+    background_tasks: BackgroundTasks,
+) -> Message:
     """
     Password Recovery
     """
@@ -64,13 +67,11 @@ def recover_password(email: str, session: SessionDep) -> Message:
             detail="The user with this email does not exist in the system.",
         )
     password_reset_token = generate_password_reset_token(email=email)
-    email_data = generate_reset_password_email(
-        email_to=user.email, email=email, token=password_reset_token
-    )
-    send_email(
+    background_tasks.add_task(
+        send_password_recovery_email,
         email_to=user.email,
-        subject=email_data.subject,
-        html_content=email_data.html_content,
+        email=email,
+        token=password_reset_token,
     )
     return Message(message="Password recovery email sent")
 
@@ -115,7 +116,10 @@ def recover_password_html_content(email: str, session: SessionDep) -> Any:
             detail="The user with this username does not exist in the system.",
         )
     password_reset_token = generate_password_reset_token(email=email)
-    email_data = generate_reset_password_email(
+    # Reuse the same template building logic as the notification service
+    from app.notifications.service import _build_reset_password_email  # type: ignore[import-not-found]
+
+    email_data = _build_reset_password_email(
         email_to=user.email, email=email, token=password_reset_token
     )
 

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -24,7 +24,7 @@ from app.models import (
     UserUpdate,
     UserUpdateMe,
 )
-from app.utils import generate_new_account_email, send_email
+from app.notifications import send_welcome_email
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -51,7 +51,12 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(
+    *,
+    session: SessionDep,
+    user_in: UserCreate,
+    background_tasks: BackgroundTasks,
+) -> Any:
     """
     Create new user.
     """
@@ -64,13 +69,11 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
 
     user = crud.create_user(session=session, user_create=user_in)
     if settings.emails_enabled and user_in.email:
-        email_data = generate_new_account_email(
-            email_to=user_in.email, username=user_in.email, password=user_in.password
-        )
-        send_email(
+        background_tasks.add_task(
+            send_welcome_email,
             email_to=user_in.email,
-            subject=email_data.subject,
-            html_content=email_data.html_content,
+            username=user_in.email,
+            password=user_in.password,
         )
     return user
 

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 from pydantic.networks import EmailStr
 
 from app.api.deps import get_current_active_superuser
 from app.models import Message
-from app.utils import generate_test_email, send_email
+from app.notifications import send_test_email
 
 router = APIRouter(prefix="/utils", tags=["utils"])
 
@@ -13,16 +13,11 @@ router = APIRouter(prefix="/utils", tags=["utils"])
     dependencies=[Depends(get_current_active_superuser)],
     status_code=201,
 )
-def test_email(email_to: EmailStr) -> Message:
+def test_email(email_to: EmailStr, background_tasks: BackgroundTasks) -> Message:
     """
     Test emails.
     """
-    email_data = generate_test_email(email_to=email_to)
-    send_email(
-        email_to=email_to,
-        subject=email_data.subject,
-        html_content=email_data.html_content,
-    )
+    background_tasks.add_task(send_test_email, email_to=email_to)
     return Message(message="Test email sent")
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str | None = None
     EMAILS_FROM_EMAIL: EmailStr | None = None
     EMAILS_FROM_NAME: EmailStr | None = None
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "console"
 
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:

--- a/backend/app/notifications/__init__.py
+++ b/backend/app/notifications/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from app.notifications.providers import get_notification_provider
+from app.notifications.service import (
+    send_password_recovery_email,
+    send_test_email,
+    send_welcome_email,
+)
+
+__all__ = [
+    "get_notification_provider",
+    "send_password_recovery_email",
+    "send_test_email",
+    "send_welcome_email",
+]

--- a/backend/app/notifications/providers/__init__.py
+++ b/backend/app/notifications/providers/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from app.core.config import settings
+from app.notifications.providers.base import EmailMessage, NotificationProvider
+from app.notifications.providers.console import ConsoleNotificationProvider
+from app.notifications.providers.smtp import SMTPNotificationProvider
+
+ProviderName = Literal["console", "smtp"]
+
+
+@lru_cache(maxsize=1)
+def get_notification_provider() -> NotificationProvider:
+    provider_name: ProviderName = settings.NOTIFICATIONS_PROVIDER
+    if provider_name == "smtp":
+        return SMTPNotificationProvider()
+    return ConsoleNotificationProvider()
+
+
+__all__ = [
+    "EmailMessage",
+    "NotificationProvider",
+    "get_notification_provider",
+]

--- a/backend/app/notifications/providers/base.py
+++ b/backend/app/notifications/providers/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class EmailMessage:
+    email_to: str
+    subject: str
+    html_content: str
+
+
+class NotificationError(Exception):
+    """Raised when a notification provider fails to send a message."""
+
+
+class NotificationProvider(ABC):
+    @abstractmethod
+    def send_email(self, message: EmailMessage) -> None:
+        """Send an email notification."""
+        raise NotImplementedError

--- a/backend/app/notifications/providers/console.py
+++ b/backend/app/notifications/providers/console.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+
+from app.notifications.providers.base import EmailMessage, NotificationProvider
+
+logger = logging.getLogger("notifications.console")
+
+
+class ConsoleNotificationProvider(NotificationProvider):
+    """Notification provider that logs emails to the console."""
+
+    def send_email(self, message: EmailMessage) -> None:
+        logger.info(
+            "Sending email via console provider",
+            extra={
+                "provider": "console",
+                "email_to": message.email_to,
+                "subject": message.subject,
+            },
+        )
+        logger.info("Email content: %s", message.html_content)

--- a/backend/app/notifications/providers/smtp.py
+++ b/backend/app/notifications/providers/smtp.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import emails  # type: ignore
+
+from app.core.config import settings
+from app.notifications.providers.base import EmailMessage, NotificationError, NotificationProvider
+
+logger = logging.getLogger("notifications.smtp")
+
+
+class SMTPNotificationProvider(NotificationProvider):
+    """Notification provider that sends emails using SMTP."""
+
+    def _build_smtp_options(self) -> dict[str, Any]:
+        smtp_options: dict[str, Any] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        return smtp_options
+
+    def send_email(self, message: EmailMessage) -> None:
+        if not settings.emails_enabled:
+            logger.warning(
+                "Attempted to send email with SMTP provider but emails are disabled",
+                extra={"provider": "smtp", "email_to": message.email_to},
+            )
+            return
+
+        smtp_options = self._build_smtp_options()
+        logger.info(
+            "Sending email via SMTP provider",
+            extra={
+                "provider": "smtp",
+                "email_to": message.email_to,
+                "subject": message.subject,
+                "smtp_host": settings.SMTP_HOST,
+                "smtp_port": settings.SMTP_PORT,
+            },
+        )
+        try:
+            email_message = emails.Message(
+                subject=message.subject,
+                html=message.html_content,
+                mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+            )
+            response = email_message.send(to=message.email_to, smtp=smtp_options)
+            logger.info(
+                "Email sent successfully via SMTP provider",
+                extra={
+                    "provider": "smtp",
+                    "email_to": message.email_to,
+                    "subject": message.subject,
+                    "response": str(response),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "Failed to send email via SMTP provider",
+                extra={
+                    "provider": "smtp",
+                    "email_to": message.email_to,
+                    "subject": message.subject,
+                },
+            )
+            raise NotificationError("Error sending email via SMTP provider") from exc

--- a/backend/app/notifications/service.py
+++ b/backend/app/notifications/service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.config import settings
+from app.notifications.providers import EmailMessage, get_notification_provider
+from app.utils import render_email_template
+
+
+@dataclass(slots=True)
+class EmailData:
+    html_content: str
+    subject: str
+
+
+def _build_test_email(email_to: str) -> EmailData:
+    project_name = settings.PROJECT_NAME
+    subject = f"{project_name} - Test email"
+    html_content = render_email_template(
+        template_name="test_email.html",
+        context={"project_name": settings.PROJECT_NAME, "email": email_to},
+    )
+    return EmailData(html_content=html_content, subject=subject)
+
+
+def _build_reset_password_email(email_to: str, email: str, token: str) -> EmailData:
+    project_name = settings.PROJECT_NAME
+    subject = f"{project_name} - Password recovery for user {email}"
+    link = f"{settings.FRONTEND_HOST}/reset-password?token={token}"
+    html_content = render_email_template(
+        template_name="reset_password.html",
+        context={
+            "project_name": settings.PROJECT_NAME,
+            "username": email,
+            "email": email_to,
+            "valid_hours": settings.EMAIL_RESET_TOKEN_EXPIRE_HOURS,
+            "link": link,
+        },
+    )
+    return EmailData(html_content=html_content, subject=subject)
+
+
+def _build_new_account_email(
+    email_to: str, username: str, password: str
+) -> EmailData:
+    project_name = settings.PROJECT_NAME
+    subject = f"{project_name} - New account for user {username}"
+    html_content = render_email_template(
+        template_name="new_account.html",
+        context={
+            "project_name": settings.PROJECT_NAME,
+            "username": username,
+            "password": password,
+            "email": email_to,
+            "link": settings.FRONTEND_HOST,
+        },
+    )
+    return EmailData(html_content=html_content, subject=subject)
+
+
+def send_test_email(email_to: str) -> None:
+    email_data = _build_test_email(email_to=email_to)
+    provider = get_notification_provider()
+    provider.send_email(
+        EmailMessage(
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+    )
+
+
+def send_password_recovery_email(email_to: str, email: str, token: str) -> None:
+    email_data = _build_reset_password_email(
+        email_to=email_to, email=email, token=token
+    )
+    provider = get_notification_provider()
+    provider.send_email(
+        EmailMessage(
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+    )
+
+
+def send_welcome_email(email_to: str, username: str, password: str) -> None:
+    email_data = _build_new_account_email(
+        email_to=email_to, username=username, password=password
+    )
+    provider = get_notification_provider()
+    provider.send_email(
+        EmailMessage(
+            email_to=email_to,
+            subject=email_data.subject,
+            html_content=email_data.html_content,
+        )
+    )

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,25 +1,13 @@
-import logging
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class EmailData:
-    html_content: str
-    subject: str
 
 
 def render_email_template(*, template_name: str, context: dict[str, Any]) -> str:
@@ -28,76 +16,6 @@ def render_email_template(*, template_name: str, context: dict[str, Any]) -> str
     ).read_text()
     html_content = Template(template_str).render(context)
     return html_content
-
-
-def send_email(
-    *,
-    email_to: str,
-    subject: str = "",
-    html_content: str = "",
-) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
-        subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
-    )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
-
-
-def generate_test_email(email_to: str) -> EmailData:
-    project_name = settings.PROJECT_NAME
-    subject = f"{project_name} - Test email"
-    html_content = render_email_template(
-        template_name="test_email.html",
-        context={"project_name": settings.PROJECT_NAME, "email": email_to},
-    )
-    return EmailData(html_content=html_content, subject=subject)
-
-
-def generate_reset_password_email(email_to: str, email: str, token: str) -> EmailData:
-    project_name = settings.PROJECT_NAME
-    subject = f"{project_name} - Password recovery for user {email}"
-    link = f"{settings.FRONTEND_HOST}/reset-password?token={token}"
-    html_content = render_email_template(
-        template_name="reset_password.html",
-        context={
-            "project_name": settings.PROJECT_NAME,
-            "username": email,
-            "email": email_to,
-            "valid_hours": settings.EMAIL_RESET_TOKEN_EXPIRE_HOURS,
-            "link": link,
-        },
-    )
-    return EmailData(html_content=html_content, subject=subject)
-
-
-def generate_new_account_email(
-    email_to: str, username: str, password: str
-) -> EmailData:
-    project_name = settings.PROJECT_NAME
-    subject = f"{project_name} - New account for user {username}"
-    html_content = render_email_template(
-        template_name="new_account.html",
-        context={
-            "project_name": settings.PROJECT_NAME,
-            "username": username,
-            "password": password,
-            "email": email_to,
-            "link": settings.FRONTEND_HOST,
-        },
-    )
-    return EmailData(html_content=html_content, subject=subject)
 
 
 def generate_password_reset_token(email: str) -> str:

--- a/backend/tests/test_notifications_providers.py
+++ b/backend/tests/test_notifications_providers.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.notifications.providers import EmailMessage, get_notification_provider
+from app.notifications.providers.console import ConsoleNotificationProvider
+from app.notifications.providers.smtp import SMTPNotificationProvider
+
+
+def test_get_notification_provider_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "console")
+    provider = get_notification_provider()
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+
+def test_get_notification_provider_smtp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "smtp")
+    provider = get_notification_provider()
+    assert isinstance(provider, SMTPNotificationProvider)
+
+
+def test_smtp_provider_builds_smtp_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "smtp")
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(settings, "SMTP_PORT", 2525)
+    monkeypatch.setattr(settings, "SMTP_TLS", True)
+    monkeypatch.setattr(settings, "SMTP_SSL", False)
+    monkeypatch.setattr(settings, "SMTP_USER", "user")
+    monkeypatch.setattr(settings, "SMTP_PASSWORD", "pass")
+    provider = get_notification_provider()
+    assert isinstance(provider, SMTPNotificationProvider)
+
+    smtp_options = provider._build_smtp_options()  # type: ignore[attr-defined]
+    assert smtp_options["host"] == "smtp.example.com"
+    assert smtp_options["port"] == 2525
+    assert smtp_options["tls"] is True
+    assert "ssl" not in smtp_options
+    assert smtp_options["user"] == "user"
+    assert smtp_options["password"] == "pass"
+
+
+def test_smtp_provider_send_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "smtp")
+    monkeypatch.setattr(settings, "SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(settings, "EMAILS_FROM_EMAIL", "info@example.com")
+    monkeypatch.setattr(settings, "EMAILS_FROM_NAME", "Example")
+    monkeypatch.setattr(settings, "SMTP_PORT", 2525)
+    monkeypatch.setattr(settings, "SMTP_TLS", True)
+    monkeypatch.setattr(settings, "SMTP_SSL", False)
+
+    sent_messages: list[dict[str, Any]] = []
+
+    class DummyEmailMessage:
+        def __init__(self, subject: str, html: str, mail_from: tuple[str, str]) -> None:
+            self.subject = subject
+            self.html = html
+            self.mail_from = mail_from
+
+        def send(self, to: str, smtp: dict[str, Any]) -> str:
+            sent_messages.append(
+                {
+                    "to": to,
+                    "smtp": smtp,
+                    "subject": self.subject,
+                    "html": self.html,
+                    "mail_from": self.mail_from,
+                }
+            )
+            return "ok"
+
+    import app.notifications.providers.smtp as smtp_module
+
+    monkeypatch.setattr(smtp_module, "emails", type("EmailsModule", (), {"Message": DummyEmailMessage}))
+
+    provider = get_notification_provider()
+    assert isinstance(provider, SMTPNotificationProvider)
+
+    message = EmailMessage(
+        email_to="user@example.com",
+        subject="Subject",
+        html_content="<p>Hello</p>",
+    )
+    provider.send_email(message)
+
+    assert len(sent_messages) == 1
+    sent = sent_messages[0]
+    assert sent["to"] == "user@example.com"
+    assert sent["subject"] == "Subject"
+    assert sent["html"] == "<p>Hello</p>"

--- a/frontend/src/routes/recover-password.tsx
+++ b/frontend/src/routes/recover-password.tsx
@@ -45,7 +45,7 @@ function RecoverPassword() {
   const mutation = useMutation({
     mutationFn: recoverPassword,
     onSuccess: () => {
-      showSuccessToast("Password recovery email sent successfully.")
+      showSuccessToast("If an account exists for this email, a recovery link has been sent.")
       reset()
     },
     onError: (err: ApiError) => {
@@ -86,7 +86,12 @@ function RecoverPassword() {
           />
         </InputGroup>
       </Field>
-      <Button variant="solid" type="submit" loading={isSubmitting}>
+      <Button
+        variant="solid"
+        type="submit"
+        loading={isSubmitting || mutation.isPending}
+        isDisabled={mutation.isPending}
+      >
         Continue
       </Button>
     </Container>


### PR DESCRIPTION
- Introduced a notifications subsystem under backend/app/notifications with a provider interface and two providers: console (local development) and smtp (real emails). Added a get_notification_provider() factory that selects provider based on NOTIFICATIONS_PROVIDER in settings, defaulting to console.
- Added service layer to build emails (password recovery, welcome/new account, test) using templates and to send via the selected provider. Exposed send_password_recovery_email, send_welcome_email, and send_test_email for use by API routes.
- Refactored routes to send emails asynchronously using FastAPI BackgroundTasks (e.g., password recovery and new user signup), so API responses return quickly while emails are sent in the background.
- Removed legacy inline email sending logic from backend/app/utils.py and replaced usage with the new notification service.
- Added unit tests (backend/tests/test_notifications_providers.py) to validate provider resolution, SMTP option building, and email sending behavior using a test double for SMTP.
- Env and docs updates: .env now includes NOTIFICATIONS_PROVIDER and SMTP-related fields; backend/README.md gains a Notifications section detailing providers, configuration, and flows. 
- Frontend tweak: forgot password success message updated to a generic optimistic message and the button loading/disabled state improved for better UX.
- All changes are designed to be CI-friendly and support switching between providers with minimal code changes.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/u11oj9pz64v9](https://cosine.sh/cosinedemo/full-stack-demo/task/u11oj9pz64v9)
Author: James White
