### PR TITLE
Return 409 Conflict with JSON error on signup duplicates and show inline frontend error

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -146,9 +147,9 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email"},
         )
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -316,8 +316,8 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "email"}
 
 
 def test_update_user(

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -8,12 +8,13 @@ import { type SubmitHandler, useForm } from "react-hook-form"
 import { FiLock, FiUser } from "react-icons/fi"
 
 import type { UserRegister } from "@/client"
+import type { ApiError } from "@/client/core/ApiError"
 import { Button } from "@/components/ui/button"
 import { Field } from "@/components/ui/field"
 import { InputGroup } from "@/components/ui/input-group"
 import { PasswordInput } from "@/components/ui/password-input"
 import useAuth, { isLoggedIn } from "@/hooks/useAuth"
-import { confirmPasswordRules, emailPattern, passwordRules } from "@/utils"
+import { confirmPasswordRules, emailPattern, passwordRules, handleError } from "@/utils"
 import Logo from "/assets/images/fastapi-logo.svg"
 
 export const Route = createFileRoute("/signup")({
@@ -37,6 +38,7 @@ function SignUp() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<UserRegisterForm>({
     mode: "onBlur",
@@ -49,8 +51,26 @@ function SignUp() {
     },
   })
 
-  const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+  const onSubmit: SubmitHandler<UserRegisterForm> = async (data) => {
+    try {
+      await signUpMutation.mutateAsync(data)
+    } catch (error) {
+      const apiError = error as ApiError
+      const body = (apiError.body || {}) as any
+
+      if (body.error === "conflict") {
+        const field = body.field
+
+        if (field === "email" || field === "username") {
+          setError("email", {
+            type: "server",
+            message: "Email already in use",
+          })
+        }
+      } else {
+        handleError(apiError)
+      }
+    }
   }
 
   return (

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -95,9 +95,7 @@ test("Sign up with existing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  await expect(page.getByText("Email already in use")).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {


### PR DESCRIPTION
Summary:
- Backend now returns a 409 Conflict with a consistent JSON body when attempting to sign up with a duplicate email (and similarly for username in the future), instead of a 400 with a string detail.
- Frontend reads the JSON error body and renders an inline form error for the email/username field.
- Tests updated to reflect the new error payload and UI behavior.

What changed:
- Backend: backend/app/api/routes/users.py
  - Imported JSONResponse.
  - On detecting an existing user by email during signup, return a JSONResponse with status_code 409 and content {"error": "conflict", "field": "email"} instead of raising HTTPException with a 400 and a detail message.
  - This aligns with enforced DB uniqueness and provides a consistent error payload for both API consumers and the frontend.

- Tests: backend/tests/api/routes/test_users.py
  - Updated test_register_user_already_exists_error to expect status 409 and body {"error": "conflict", "field": "email"}.

- Frontend: frontend/src/routes/signup.tsx
  - Import ApiError type and handleError utility.
  - On signup failure, parse the API error body. If body.error === "conflict" and body.field is either "email" or "username", set a server-side form error on the email field with message "Email already in use".
  - Fallback to handleError for other errors.

- Frontend tests and Playwright: frontend/tests/sign-up.spec.ts
  - Updated assertion to check for visible inline text "Email already in use" instead of a generic server message.

How this solves the issue:
- Ensures signup failures due to duplicate email/username are consistently reported with HTTP 409 and a structured JSON payload.
- Frontend shows a user-friendly inline error tied to the relevant form field, improving UX and aligning with tests.
- Unit and Playwright tests are updated to validate the new behavior.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/ulh226darqqy](https://cosine.sh/cosinedemo/full-stack-demo/task/ulh226darqqy)
Author: Des Kramer
