### PR TITLE
feat: unify duplicate-user handling for signup with 409 conflict and inline UI errors

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -57,9 +58,9 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system.",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email"},
         )
 
     user = crud.create_user(session=session, user_create=user_in)
@@ -146,9 +147,9 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
+        return JSONResponse(
+            status_code=409,
+            content={"error": "conflict", "field": "email"},
         )
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -128,8 +128,8 @@ def test_create_user_existing_username(
         json=data,
     )
     created_user = r.json()
-    assert r.status_code == 400
-    assert "_id" not in created_user
+    assert r.status_code == 409
+    assert created_user == {"error": "conflict", "field": "email"}
 
 
 def test_create_user_by_normal_user(
@@ -316,8 +316,8 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "email"}
 
 
 def test_update_user(

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -3,17 +3,20 @@ import {
   createFileRoute,
   Link as RouterLink,
   redirect,
+  useNavigate,
 } from "@tanstack/react-router"
+import { useMutation } from "@tanstack/react-query"
 import { type SubmitHandler, useForm } from "react-hook-form"
 import { FiLock, FiUser } from "react-icons/fi"
 
-import type { UserRegister } from "@/client"
+import type { ApiError, UserRegister } from "@/client"
+import { UsersService } from "@/client"
 import { Button } from "@/components/ui/button"
 import { Field } from "@/components/ui/field"
 import { InputGroup } from "@/components/ui/input-group"
 import { PasswordInput } from "@/components/ui/password-input"
-import useAuth, { isLoggedIn } from "@/hooks/useAuth"
-import { confirmPasswordRules, emailPattern, passwordRules } from "@/utils"
+import { isLoggedIn } from "@/hooks/useAuth"
+import { confirmPasswordRules, emailPattern, handleError, passwordRules } from "@/utils"
 import Logo from "/assets/images/fastapi-logo.svg"
 
 export const Route = createFileRoute("/signup")({
@@ -32,11 +35,12 @@ interface UserRegisterForm extends UserRegister {
 }
 
 function SignUp() {
-  const { signUpMutation } = useAuth()
+  const navigate = useNavigate()
   const {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<UserRegisterForm>({
     mode: "onBlur",
@@ -46,6 +50,27 @@ function SignUp() {
       full_name: "",
       password: "",
       confirm_password: "",
+    },
+  })
+
+  const signUpMutation = useMutation({
+    mutationFn: (data: UserRegister) =>
+      UsersService.registerUser({ requestBody: data }),
+    onSuccess: () => {
+      navigate({ to: "/login" })
+    },
+    onError: (err: ApiError) => {
+      const body = err.body as any
+      if (err.status === 409 && body?.error === "conflict") {
+        if (body.field === "email") {
+          setError("email", {
+            type: "server",
+            message: "The user with this email already exists in the system",
+          })
+          return
+        }
+      }
+      handleError(err)
     },
   })
 

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -95,9 +95,9 @@ test("Sign up with existing email", async ({ page }) => {
   await fillForm(page, fullName, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  await expect(
+    page.getByText("The user with this email already exists in the system"),
+  ).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {


### PR DESCRIPTION
This PR fixes ISSUE #532 by standardizing how duplicate users are reported during signup and surfacing a simple inline error in the UI.

What changed:
- Backend
  - API now returns HTTP 409 with a concise error payload when a duplicate email is detected during user creation or signup.
  - Response body for duplicates: {"error": "conflict", "field": "email"}.
  - Added JSONResponse import and adjusted responses accordingly.
  - Note: DB is expected to enforce unique constraints on email and username (as per acceptance criteria).

- Frontend
  - Signup flow now handles 409/conflict responses and shows an inline error on the email field with the message: "The user with this email already exists in the system".
  - Added navigation to login on successful signup.
  - Uses a unified error handling path for other errors via handleError.
  - Updated type usage to reflect ApiError and structured error body.

- Tests
  - Backend tests updated to expect 409 status and payload {"error": "conflict", "field": "email"} for duplicate email cases.
  - Frontend tests updated to verify the inline email error appears when signup with an existing email is attempted.
  - Basic unit and e2e tests cover duplicate email scenarios.

Impact:
- Consistent error shape across API clients and a straightforward UI cue for duplicates.
- Easier UI integration for inline form validation without parsing verbose error messages.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/vfxhvrojnm4i](https://cosine.sh/cosinedemo/full-stack-demo/task/vfxhvrojnm4i)
Author: James White
