### PR TITLE
Add a pluggable email notifications service with Console and SMTP providers behind NOTIFICATIONS_PROVIDER

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -170,3 +170,14 @@ The email templates are in `./backend/app/email-templates/`. Here, there are two
 Before continuing, ensure you have the [MJML extension](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml) installed in your VS Code.
 
 Once you have the MJML extension installed, you can create a new email template in the `src` directory. After creating the new email template and with the `.mjml` file open in your editor, open the command palette with `Ctrl+Shift+P` and search for `MJML: Export to HTML`. This will convert the `.mjml` file to a `.html` file and now you can save it in the build directory.
+
+## Notifications Provider
+
+Email notifications (welcome, password reset, etc.) are sent through a simple notifications service with pluggable providers.
+
+The provider is selected with the environment variable:
+
+- `NOTIFICATIONS_PROVIDER=console` – emails are not sent, but their contents are logged to the backend logs. Useful in local development.
+- `NOTIFICATIONS_PROVIDER=smtp` – emails are sent via the configured SMTP server (default).
+
+If `NOTIFICATIONS_PROVIDER` is not set, it defaults to `smtp`, preserving the current behavior as long as SMTP is configured (see the SMTP-related settings above).

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):
     EMAILS_FROM_EMAIL: EmailStr | None = None
     EMAILS_FROM_NAME: EmailStr | None = None
 
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
+
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:
         if not self.EMAILS_FROM_NAME:

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,68 @@
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmailMessage:
+    email_to: str
+    subject: str
+    html_content: str
+
+
+class NotificationProviderName(str, Enum):
+    SMTP = "smtp"
+    CONSOLE = "console"
+
+
+class NotificationProvider:
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ConsoleNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            "Console notification email\nTo: %s\nSubject: %s\nBody:\n%s",
+            email_to,
+            subject,
+            html_content,
+        )
+
+
+class SMTPNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        # Import here so that environments not using SMTP don't require the dependency eagerly.
+        import emails  # type: ignore
+
+        assert settings.emails_enabled, "no provided configuration for email variables"
+        message = emails.Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        response = message.send(to=email_to, smtp=smtp_options)
+        logger.info("send email result: %s", response)
+
+
+@lru_cache
+def get_notification_provider() -> NotificationProvider:
+    provider_name = settings.NOTIFICATIONS_PROVIDER
+    if provider_name == NotificationProviderName.CONSOLE:
+        return ConsoleNotificationProvider()
+    # Default to SMTP for any other value to keep behavior consistent.
+    return SMTPNotificationProvider()

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import get_notification_provider
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,23 +36,12 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
+    provider = get_notification_provider()
+    provider.send_email(
+        email_to=email_to,
         subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        html_content=html_content,
     )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/utils/test_notifications.py
+++ b/backend/tests/utils/test_notifications.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+from app.core.config import settings
+from app.notifications import (
+    ConsoleNotificationProvider,
+    SMTPNotificationProvider,
+    get_notification_provider,
+)
+
+
+def test_console_notification_provider_logs(caplog) -> None:
+    provider = ConsoleNotificationProvider()
+    with caplog.at_level("INFO"):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test",
+            html_content="<p>Hello</p>",
+        )
+    # Ensure that something was logged with the expected pieces of data.
+    joined = "\n".join(caplog.messages)
+    assert "Console notification email" in joined
+    assert "user@example.com" in joined
+    assert "Test" in joined
+    assert "Hello" in joined
+
+
+def test_smtp_notification_provider_uses_emails_library(monkeypatch) -> None:
+    sent_args: dict[str, object] = {}
+
+    class DummyMessage:
+        def __init__(self, subject: str, html: str, mail_from: tuple[str, str | None]):
+            self.subject = subject
+            self.html = html
+            self.mail_from = mail_from
+
+        def send(self, to: str, smtp: dict[str, object]) -> str:
+            sent_args["to"] = to
+            sent_args["smtp"] = smtp
+            sent_args["subject"] = self.subject
+            sent_args["html"] = self.html
+            return "ok"
+
+    dummy_emails = MagicMock()
+    dummy_emails.Message = DummyMessage  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("app.notifications.emails", dummy_emails, raising=False)
+
+    # Ensure settings are populated for the SMTP provider.
+    with (
+        patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
+        patch("app.core.config.settings.SMTP_PORT", 587),
+        patch("app.core.config.settings.SMTP_TLS", True),
+        patch("app.core.config.settings.SMTP_SSL", False),
+        patch("app.core.config.settings.SMTP_USER", "user"),
+        patch("app.core.config.settings.SMTP_PASSWORD", "pass"),
+        patch("app.core.config.settings.EMAILS_FROM_EMAIL", "noreply@example.com"),
+        patch("app.core.config.settings.EMAILS_FROM_NAME", "Example App"),
+    ):
+        provider = SMTPNotificationProvider()
+        provider.send_email(
+            email_to="dest@example.com",
+            subject="Subject",
+            html_content="<p>Body</p>",
+        )
+
+    assert sent_args["to"] == "dest@example.com"
+    smtp = sent_args["smtp"]
+    assert isinstance(smtp, dict)
+    assert smtp["host"] == "smtp.example.com"
+    assert smtp["port"] == 587
+    assert smtp["tls"] is True
+    assert smtp["user"] == "user"
+    assert smtp["password"] == "pass"
+    assert sent_args["subject"] == "Subject"
+    assert sent_args["html"] == "<p>Body</p>"
+
+
+def test_get_notification_provider_uses_env(monkeypatch) -> None:
+    monkeypatch.setattr("app.core.config.settings.NOTIFICATIONS_PROVIDER", "console")
+    provider = get_notification_provider()
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+    # Clear the cache and switch provider.
+    get_notification_provider.cache_clear()  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("app.core.config.settings.NOTIFICATIONS_PROVIDER", "smtp")
+    provider = get_notification_provider()
+    from app.notifications import SMTPNotificationProvider as SMTPProviderCls
+
+    assert isinstance(provider, SMTPProviderCls)


### PR DESCRIPTION
Introduce a simple, pluggable notifications service to handle email sends (welcome, password reset) via two providers: console (logs emails) and SMTP (actual sending).

What changed:
- Backend:
  - Added NOTIFICATIONS_PROVIDER config (values: console or smtp) with default smtp to preserve current behavior when SMTP is configured.
  - Added app/notifications.py implementing:
    - NotificationProvider interface
    - ConsoleNotificationProvider (logs email contents)
    - SMTPNotificationProvider (uses the emails library to send via SMTP)
    - get_notification_provider() with caching to select provider based on env value
  - Wired email sending to use the notifications provider in app/utils.py instead of direct SMTP/email code.
  - Updated tests (backend/tests/utils/test_notifications.py) including tests for Console and SMTP providers and provider selection logic.
  - Updated README with a new section describing the notifications provider and how to switch between console and smtp via NOTIFICATIONS_PROVIDER.

- Frontend:
  - No UI changes; behavior remains the same from the user perspective.

Impact:
- Current SMTP-based sending remains the default behavior when SMTP is configured, ensuring backward compatibility.
- Developers can switch to console provider for local development by setting NOTIFICATIONS_PROVIDER=console, which logs email content instead of sending. Tests verify both providers and provider selection.


---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/ehmbfonbhmf5](https://cosine.sh/cosinedemo/full-stack-demo/task/ehmbfonbhmf5)
Author: Des Kramer
