### PR TITLE
Add pluggable notification provider for emails with console and SMTP options

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -170,3 +170,16 @@ The email templates are in `./backend/app/email-templates/`. Here, there are two
 Before continuing, ensure you have the [MJML extension](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml) installed in your VS Code.
 
 Once you have the MJML extension installed, you can create a new email template in the `src` directory. After creating the new email template and with the `.mjml` file open in your editor, open the command palette with `Ctrl+Shift+P` and search for `MJML: Export to HTML`. This will convert the `.mjml` file to a `.html` file and now you can save it in the build directory.
+
+## Notification Provider
+
+Email sending is handled by a simple notifications service with pluggable providers.
+
+By default, the backend uses the SMTP provider, which sends real emails using the configured SMTP settings (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, etc.).
+
+You can switch between providers with the `NOTIFICATIONS_PROVIDER` environment variable in your `.env` file:
+
+- `NOTIFICATIONS_PROVIDER=smtp` – use the SMTP provider (default).
+- `NOTIFICATIONS_PROVIDER=console` – use the console provider, which only logs email contents instead of sending real emails.
+
+No frontend changes are required; existing flows (welcome and password reset emails) will automatically use the selected provider.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     FRONTEND_HOST: str = "http://localhost:5173"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
+    NOTIFICATIONS_PROVIDER: Literal["smtp", "console"] = "smtp"
 
     BACKEND_CORS_ORIGINS: Annotated[
         list[AnyUrl] | str, BeforeValidator(parse_cors)

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Protocol
+
+import emails  # type: ignore
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationProvider(Protocol):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None: ...
+
+
+class ConsoleNotificationProvider:
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            "ConsoleNotificationProvider - email:\nTo: %s\nSubject: %s\nContent: %s",
+            email_to,
+            subject,
+            html_content,
+        )
+
+
+class SMTPNotificationProvider:
+    def __init__(self) -> None:
+        if not settings.emails_enabled:
+            msg = "Email configuration is missing; cannot use SMTP notification provider"
+            raise RuntimeError(msg)
+
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        message = emails.Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        response = message.send(to=email_to, smtp=smtp_options)
+        logger.info("SMTPNotificationProvider - send email result: %s", response)
+
+
+def get_notification_provider() -> NotificationProvider:
+    provider_name = settings.NOTIFICATIONS_PROVIDER
+    if provider_name == "console":
+        return ConsoleNotificationProvider()
+    return SMTPNotificationProvider()
+
+
+notifications = get_notification_provider()

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import notifications
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,23 +36,11 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
+    notifications.send_email(
+        email_to=email_to,
         subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        html_content=html_content,
     )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/utils/test_notifications.py
+++ b/backend/tests/utils/test_notifications.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.notifications import (
+    ConsoleNotificationProvider,
+    SMTPNotificationProvider,
+)
+
+
+def test_console_notification_provider_logs(caplog: pytest.LogCaptureFixture) -> None:
+    provider = ConsoleNotificationProvider()
+    with caplog.at_level("INFO"):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Subject",
+            html_content="<p>Body</p>",
+        )
+    assert any("ConsoleNotificationProvider - email:" in message for message in caplog.text.splitlines())
+
+
+def test_smtp_notification_provider_sends_email() -> None:
+    with (
+        patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
+        patch("app.core.config.settings.EMAILS_FROM_EMAIL", "no-reply@example.com"),
+        patch("app.core.config.settings.EMAILS_FROM_NAME", "Example"),
+        patch("app.notifications.emails.Message") as message_cls,
+    ):
+        message_instance = MagicMock()
+        message_cls.return_value = message_instance
+
+        provider = SMTPNotificationProvider()
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Subject",
+            html_content="<p>Body</p>",
+        )
+
+        message_cls.assert_called_once()
+        message_instance.send.assert_called_once()


### PR DESCRIPTION
Overview:
- Introduced a simple, pluggable notifications service to handle email sending behind a provider interface.
- Added two providers: Console (logs emails) and SMTP (sends real emails).
- Wire existing flows to use the new service without frontend changes.
- Configurable via environment variable NOTIFICATIONS_PROVIDER (defaults to smtp).
- Updated tests to cover both providers and added README guidance on switching providers.

What changed:
- backend/app/notifications.py (new):
  - Defined NotificationProvider Protocol with send_email method.
  - Implemented ConsoleNotificationProvider (logs email content) and SMTPNotificationProvider (sends real emails via the existing SMTP settings).
  - Added get_notification_provider() to select provider based on NOTIFICATIONS_PROVIDER.
  - Exposed a notifications instance wired to the chosen provider.
- backend/app/core/config.py (updated):
  - Added NOTIFICATIONS_PROVIDER: Literal["smtp", "console"] = "smtp" to settings.
- backend/app/utils.py (updated):
  - Reworked send_email to delegate to notifications.send_email(email_to, subject, html_content).
  - Removed inline SMTP-specific wiring; uses provider interface instead.
- backend/tests/utils/test_notifications.py (new):
  - Tests for ConsoleNotificationProvider (ensures logging format).
  - Tests for SMTPNotificationProvider (mocks SMTP Message to verify sending flow).
- backend/README.md (updated):
  - Added a new Notification Provider section describing:
    - Default SMTP provider and how to switch to console via NOTIFICATIONS_PROVIDER.
    - No frontend changes required; existing flows (welcome and password reset emails) will use the selected provider.

How this solves the task:
- Email sends (welcome/reset) are now routed through a unified notifications service with a pluggable provider, enabling easy switching between real SMTP emails and console logging during development or testing.
- Backend can switch providers via environment variable WITHOUT code changes, and unit tests cover both providers.
- README provides guidance on how to switch the provider.


---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/rdnt10i0k55u](https://cosine.sh/cosinedemo/full-stack-demo/task/rdnt10i0k55u)
Author: Des Kramer
