### PR TITLE
Add pluggable notifications provider (console or SMTP) and wire emails through it

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -170,3 +170,38 @@ The email templates are in `./backend/app/email-templates/`. Here, there are two
 Before continuing, ensure you have the [MJML extension](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml) installed in your VS Code.
 
 Once you have the MJML extension installed, you can create a new email template in the `src` directory. After creating the new email template and with the `.mjml` file open in your editor, open the command palette with `Ctrl+Shift+P` and search for `MJML: Export to HTML`. This will convert the `.mjml` file to a `.html` file and now you can save it in the build directory.
+
+## Notifications Provider
+
+Outgoing emails (welcome, password reset, test email) are sent through a simple notifications service with pluggable providers.
+
+The provider is selected via the `NOTIFICATIONS_PROVIDER` environment variable:
+
+- `smtp` (default) – use the SMTP configuration (`SMTP_*`, `EMAILS_FROM_*`) to send real emails.
+- `console` – log the email details to the backend logs instead of sending them.
+
+### How to switch provider
+
+1. Open your `.env` file at the project root (one level above `./backend/`).
+2. Set the provider you want to use:
+
+   ```env
+   # Log emails to the console (useful for local development)
+   NOTIFICATIONS_PROVIDER=console
+
+   # Or use real SMTP delivery
+   # NOTIFICATIONS_PROVIDER=smtp
+   ```
+
+3. Ensure your SMTP configuration is set when using `smtp`:
+
+   ```env
+   SMTP_HOST=smtp.example.com
+   SMTP_PORT=587
+   SMTP_USER=your_user
+   SMTP_PASSWORD=your_password
+   EMAILS_FROM_EMAIL=you@example.com
+   EMAILS_FROM_NAME=Your App
+   ```
+
+4. Restart the backend service so the new configuration is picked up.

--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -11,10 +11,10 @@ from app.core import security
 from app.core.config import settings
 from app.core.security import get_password_hash
 from app.models import Message, NewPassword, Token, UserPublic
+from app.notifications import send_email_notification
 from app.utils import (
     generate_password_reset_token,
     generate_reset_password_email,
-    send_email,
     verify_password_reset_token,
 )
 
@@ -67,7 +67,7 @@ def recover_password(email: str, session: SessionDep) -> Message:
     email_data = generate_reset_password_email(
         email_to=user.email, email=email, token=password_reset_token
     )
-    send_email(
+    send_email_notification(
         email_to=user.email,
         subject=email_data.subject,
         html_content=email_data.html_content,

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -24,7 +24,8 @@ from app.models import (
     UserUpdate,
     UserUpdateMe,
 )
-from app.utils import generate_new_account_email, send_email
+from app.notifications import send_email_notification
+from app.utils import generate_new_account_email
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -67,7 +68,7 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
         email_data = generate_new_account_email(
             email_to=user_in.email, username=user_in.email, password=user_in.password
         )
-        send_email(
+        send_email_notification(
             email_to=user_in.email,
             subject=email_data.subject,
             html_content=email_data.html_content,

--- a/backend/app/api/routes/utils.py
+++ b/backend/app/api/routes/utils.py
@@ -3,7 +3,8 @@ from pydantic.networks import EmailStr
 
 from app.api.deps import get_current_active_superuser
 from app.models import Message
-from app.utils import generate_test_email, send_email
+from app.notifications import send_email_notification
+from app.utils import generate_test_email
 
 router = APIRouter(prefix="/utils", tags=["utils"])
 
@@ -18,7 +19,7 @@ def test_email(email_to: EmailStr) -> Message:
     Test emails.
     """
     email_data = generate_test_email(email_to=email_to)
-    send_email(
+    send_email_notification(
         email_to=email_to,
         subject=email_data.subject,
         html_content=email_data.html_content,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
     FRONTEND_HOST: str = "http://localhost:5173"
     ENVIRONMENT: Literal["local", "staging", "production"] = "local"
 
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
+
     BACKEND_CORS_ORIGINS: Annotated[
         list[AnyUrl] | str, BeforeValidator(parse_cors)
     ] = []

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,70 @@
+import logging
+from dataclasses import dataclass
+from typing import Protocol
+
+import emails  # type: ignore
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationProvider(Protocol):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        ...
+
+
+@dataclass
+class ConsoleNotificationProvider:
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            "Console email to %s\nSubject: %s\nContent:\n%s",
+            email_to,
+            subject,
+            html_content,
+        )
+
+
+@dataclass
+class SmtpNotificationProvider:
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        assert settings.emails_enabled, "no provided configuration for email variables"
+        message = emails.Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        response = message.send(to=email_to, smtp=smtp_options)
+        logger.info("send email result: %s", response)
+
+
+_provider: NotificationProvider | None = None
+
+
+def _get_provider() -> NotificationProvider:
+    global _provider
+    if _provider is None:
+        if settings.NOTIFICATIONS_PROVIDER == "console":
+            _provider = ConsoleNotificationProvider()
+        else:
+            _provider = SmtpNotificationProvider()
+    return _provider
+
+
+def send_email_notification(
+    *, email_to: str, subject: str = "", html_content: str = ""
+) -> None:
+    provider = _get_provider()
+    provider.send_email(email_to=email_to, subject=subject, html_content=html_content)

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import send_email_notification
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,23 +36,7 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
-        subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
-    )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
+    send_email_notification(email_to=email_to, subject=subject, html_content=html_content)
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.config import settings
+from app.notifications import send_email_notification
+
+
+class DummyMessage:
+    def __init__(self, subject: str, html: str, mail_from: tuple[str | None, str | None]):
+        self.subject = subject
+        self.html = html
+        self.mail_from = mail_from
+        self.sent_with: dict[str, Any] | None = None
+
+    def send(self, to: str, smtp: dict[str, Any]) -> str:
+        self.sent_with = {"to": to, "smtp": smtp}
+        return "ok"
+
+
+def test_console_provider_uses_logging(caplog) -> None:
+    settings.NOTIFICATIONS_PROVIDER = "console"  # type: ignore[attr-defined]
+
+    caplog.set_level("INFO")
+    send_email_notification(email_to="user@example.com", subject="Subj", html_content="<p>Body</p>")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Console email to user@example.com" in message for message in messages)
+
+
+def test_smtp_provider_sends_via_emails(monkeypatch) -> None:
+    settings.NOTIFICATIONS_PROVIDER = "smtp"  # type: ignore[attr-defined]
+    settings.SMTP_HOST = "smtp.example.com"
+    settings.SMTP_PORT = 25
+    settings.EMAILS_FROM_EMAIL = "from@example.com"  # type: ignore[assignment]
+    settings.EMAILS_FROM_NAME = "From Name"  # type: ignore[assignment]
+
+    from app import notifications as notifications_module
+
+    sent: dict[str, Any] = {}
+
+    def dummy_message_factory(subject: str, html: str, mail_from: tuple[str | None, str | None]) -> DummyMessage:  # type: ignore[type-arg]
+        msg = DummyMessage(subject=subject, html=html, mail_from=mail_from)
+        sent["msg"] = msg
+        return msg
+
+    monkeypatch.setattr(notifications_module.emails, "Message", dummy_message_factory)
+
+    send_email_notification(
+        email_to="user@example.com",
+        subject="Subject",
+        html_content="<p>Body</p>",
+    )
+
+    assert "msg" in sent
+    msg = sent["msg"]
+    assert isinstance(msg, DummyMessage)
+    assert msg.subject == "Subject"
+    assert msg.mail_from == ("From Name", "from@example.com")
+    assert msg.sent_with is not None
+    assert msg.sent_with["to"] == "user@example.com"
+    assert msg.sent_with["smtp"]["host"] == "smtp.example.com"


### PR DESCRIPTION
Summary:
- Introduced a simple notifications service with two providers (Console and SMTP) and a pluggable interface.
- Wired existing email flows to use send_email_notification instead of direct email sending.
- Added environment-driven provider selection via NOTIFICATIONS_PROVIDER with default smtp.
- Added unit tests to cover both providers.
- Updated README to document how to switch provider and required SMTP config.

What changed:
- backend/app/notifications.py: New provider implementations and a small registry to instantiate the selected provider. ConsoleProvider logs email details; SmtpProvider sends real emails using the configured SMTP settings via the emails library.
- backend/app/core/config.py: Added NOTIFICATIONS_PROVIDER option (console or smtp) with default smtp.
- backend/app/utils.py: Replaced inlined email sending with a call to send_email_notification; keeps existing generate_test_email usage intact.
- backend/app/api/routes/login.py, backend/app/api/routes/users.py, backend/app/api/routes/utils.py: Replaced direct send_email calls with send_email_notification to unify behavior across flows.
- backend/tests/test_notifications.py: New tests validating console provider logging and SMTP delivery flow, using monkeypatch to simulate SMTP messages.
- README/docs: backend/README.md updated with a Notifications Provider section detailing how to switch providers and required env vars (NOTIFICATIONS_PROVIDER, SMTP_* vars).

How to switch provider:
1) Edit the project root .env and set NOTIFICATIONS_PROVIDER to console or smtp.
   NOTIFICATIONS_PROVIDER=console
   # NOTIFICATIONS_PROVIDER=smtp
2) If using smtp, ensure SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD, EMAILS_FROM_EMAIL, EMAILS_FROM_NAME are configured.
3) Restart the backend service for changes to take effect.

Notes:
- Frontend behavior remains unchanged.
- Unit tests for both providers are included and should pass with a proper environment setup.
- This change enables easy extension with additional providers in the future.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/eidbsqjvq8cj](https://cosine.sh/cosinedemo/full-stack-demo/task/eidbsqjvq8cj)
Author: Des Kramer
