### PR TITLE
Add CSV export for Items (backend export route, frontend download button, and tests)

### DIFF
--- a/backend/app/api/routes/items.py
+++ b/backend/app/api/routes/items.py
@@ -1,7 +1,10 @@
 import uuid
 from typing import Any
+from io import StringIO
+import csv
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
 from sqlmodel import func, select
 
 from app.api.deps import CurrentUser, SessionDep
@@ -39,6 +42,46 @@ def read_items(
         items = session.exec(statement).all()
 
     return ItemsPublic(data=items, count=count)
+
+
+@router.get("/export")
+def export_items(
+    session: SessionDep,
+    current_user: CurrentUser,
+    skip: int = 0,
+    limit: int = 100,
+    search: str | None = None,
+) -> Response:
+    """Export items as CSV.
+
+    Respects the same ownership rules as the standard list endpoint and supports
+    optional text search on the item title.
+    """
+
+    base_statement = select(Item)
+
+    if not current_user.is_superuser:
+        base_statement = base_statement.where(Item.owner_id == current_user.id)
+
+    if search:
+        base_statement = base_statement.where(Item.title.contains(search))
+
+    statement = base_statement.offset(skip).limit(limit)
+    items = session.exec(statement).all()
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["id", "name", "created_at"])
+    for item in items:
+        writer.writerow(
+            [
+                str(item.id),
+                item.title,
+                item.created_at.isoformat(),
+            ]
+        )
+
+    return Response(content=output.getvalue(), media_type="text/csv")
 
 
 @router.get("/{id}", response_model=ItemPublic)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 from pydantic import EmailStr
 from sqlmodel import Field, Relationship, SQLModel
@@ -78,6 +79,7 @@ class Item(ItemBase, table=True):
     owner_id: uuid.UUID = Field(
         foreign_key="user.id", nullable=False, ondelete="CASCADE"
     )
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
     owner: User | None = Relationship(back_populates="items")
 
 

--- a/backend/tests/api/routes/test_items.py
+++ b/backend/tests/api/routes/test_items.py
@@ -79,6 +79,22 @@ def test_read_items(
     assert len(content["data"]) >= 2
 
 
+def test_export_items_csv(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    item = create_random_item(db)
+    response = client.get(
+        f"{settings.API_V1_STR}/items/export",
+        headers=superuser_token_headers,
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+
+    lines = response.text.strip().split("\n")
+    assert lines[0] == "id,name,created_at"
+    assert any(str(item.id) in line and item.title in line for line in lines[1:])
+
+
 def test_update_item(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:

--- a/frontend/src/routes/_layout/items.tsx
+++ b/frontend/src/routes/_layout/items.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Container,
   EmptyState,
   Flex,
@@ -8,10 +9,10 @@ import {
 } from "@chakra-ui/react"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { FiSearch } from "react-icons/fi"
+import { FiDownload, FiSearch } from "react-icons/fi"
 import { z } from "zod"
 
-import { ItemsService } from "@/client"
+import { ItemsService, OpenAPI } from "@/client"
 import { ItemActionsMenu } from "@/components/Common/ItemActionsMenu"
 import AddItem from "@/components/Items/AddItem"
 import PendingItems from "@/components/Pending/PendingItems"
@@ -134,11 +135,54 @@ function ItemsTable() {
 }
 
 function Items() {
+  const { page } = Route.useSearch()
+
+  const handleExport = async () => {
+    const params = new URLSearchParams()
+    params.set("skip", String((page - 1) * PER_PAGE))
+    params.set("limit", String(PER_PAGE))
+
+    const token = localStorage.getItem("access_token")
+
+    const response = await fetch(
+      `${OpenAPI.BASE}/api/v1/items/export?${params.toString()}`,
+      {
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      },
+    )
+
+    if (!response.ok) {
+      // In a real app we might want to show a toast here
+      // For now, just return silently.
+      return
+    }
+
+    const blob = await response.blob()
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = "items.csv"
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    window.URL.revokeObjectURL(url)
+  }
+
   return (
     <Container maxW="full">
-      <Heading size="lg" pt={12}>
-        Items Management
-      </Heading>
+      <Flex justify="space-between" align="center" pt={12}>
+        <Heading size="lg">Items Management</Heading>
+        <Button
+          size="sm"
+          leftIcon={<FiDownload />}
+          variant="outline"
+          onClick={handleExport}
+        >
+          Export CSV
+        </Button>
+      </Flex>
       <AddItem />
       <ItemsTable />
     </Container>


### PR DESCRIPTION
Implemented a new backend export endpoint and a corresponding frontend download workflow for Items, plus a small data model change and tests.

What changed:
- Backend
  - Added GET /api/v1/items/export to export items as CSV with headers: id,name,created_at.
  - Endpoint respects ownership: non-superusers only export their own items; optional search on title via the search query parameter.
  - Added created_at field to Item model (default to UTC now) to populate CSV as required.
  - CSV is generated in-memory using StringIO and csv.writer, returned as text/csv via FastAPI Response.
  - Extended tests with test_export_items_csv to verify status, content-type, header row, and presence of exported item data.

- Frontend
  - Added an Export CSV button on the Items list page with a download icon.
  - Button triggers a fetch to the new export endpoint, honoring current pagination (skip/limit) and authorization token when present.
  - Handles response as a blob and triggers a browser download named items.csv.
  - Minor imports updated to support the new functionality.

- Tests
  - Existing tests for reading and updating items remain intact.
  - New test ensures the export endpoint returns a valid CSV with correct header and item data.

Impact:
- Users can now export their visible Items list as CSV, including created_at timestamps, and respecting ownership and search filtering.


---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/h77lfwo6rpdq](https://cosine.sh/cosinedemo/full-stack-demo/task/h77lfwo6rpdq)
Author: Curtis Huang
