### PR TITLE
Add pluggable notifications service with Console and SMTP providers behind NOTIFICATIONS_PROVIDER

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -170,3 +170,22 @@ The email templates are in `./backend/app/email-templates/`. Here, there are two
 Before continuing, ensure you have the [MJML extension](https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml) installed in your VS Code.
 
 Once you have the MJML extension installed, you can create a new email template in the `src` directory. After creating the new email template and with the `.mjml` file open in your editor, open the command palette with `Ctrl+Shift+P` and search for `MJML: Export to HTML`. This will convert the `.mjml` file to a `.html` file and now you can save it in the build directory.
+
+## Notifications providers
+
+Email sending is handled through a simple notifications service with pluggable providers.
+
+The provider is selected via the `NOTIFICATIONS_PROVIDER` environment variable (read in `app.core.config.Settings`). Supported values are:
+
+* `smtp` (default): sends real emails using the configured SMTP settings (`SMTP_HOST`, `SMTP_PORT`, etc.).
+* `console`: does not send real emails; instead it logs the email details to the backend logs.
+
+### How to switch provider
+
+1. Open your `.env` file (one level above `./backend/`).
+2. Set `NOTIFICATIONS_PROVIDER` to one of:
+   * `NOTIFICATIONS_PROVIDER=smtp` – use the SMTP provider (requires valid SMTP configuration).
+   * `NOTIFICATIONS_PROVIDER=console` – log emails to the console instead of sending them.
+3. Restart the backend so the new configuration is picked up.
+
+All existing flows (welcome emails, password reset, test email endpoint) automatically use the selected provider; no frontend changes are required.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -84,6 +84,7 @@ class Settings(BaseSettings):
         return self
 
     EMAIL_RESET_TOKEN_EXPIRE_HOURS: int = 48
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,64 @@
+import logging
+from abc import ABC, abstractmethod
+
+import emails  # type: ignore
+
+from app.core.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationProvider(ABC):
+    @abstractmethod
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        """Send an email notification."""
+
+
+class ConsoleNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            "Console notification provider sending email",
+            extra={
+                "email_to": email_to,
+                "subject": subject,
+                "html_length": len(html_content),
+            },
+        )
+
+
+class SMTPNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        assert settings.emails_enabled, "no provided configuration for email variables"
+        message = emails.Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        response = message.send(to=email_to, smtp=smtp_options)
+        logger.info("send email result: %s", response)
+
+
+def get_notification_provider() -> NotificationProvider:
+    provider_name = getattr(settings, "NOTIFICATIONS_PROVIDER", "smtp")
+    normalized = provider_name.lower()
+    if normalized == "console":
+        return ConsoleNotificationProvider()
+    if normalized == "smtp":
+        return SMTPNotificationProvider()
+    raise ValueError(f"Unknown NOTIFICATIONS_PROVIDER: {provider_name}")
+
+
+notification_provider: NotificationProvider = get_notification_provider()

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,15 +4,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import notification_provider
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -36,23 +35,11 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
+    notification_provider.send_email(
+        email_to=email_to,
         subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        html_content=html_content,
     )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+
+from app.core.config import settings
+from app.notifications import (
+    ConsoleNotificationProvider,
+    SMTPNotificationProvider,
+    get_notification_provider,
+)
+
+
+def test_console_notification_provider_logs_email(caplog) -> None:
+    provider = ConsoleNotificationProvider()
+
+    with caplog.at_level("INFO"):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test Subject",
+            html_content="<p>Test</p>",
+        )
+
+    assert any(
+        "Console notification provider sending email" in message
+        for message in caplog.text.splitlines()
+    )
+
+
+def test_smtp_notification_provider_sends_email() -> None:
+    provider = SMTPNotificationProvider()
+
+    with (
+        patch("app.notifications.emails.Message") as message_cls,
+        patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
+        patch("app.core.config.settings.SMTP_PORT", 587),
+        patch("app.core.config.settings.EMAILS_FROM_EMAIL", "noreply@example.com"),
+    ):
+        message_instance = MagicMock()
+        message_cls.return_value = message_instance
+
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Test Subject",
+            html_content="<p>Test</p>",
+        )
+
+        message_cls.assert_called_once_with(
+            subject="Test Subject",
+            html="<p>Test</p>",
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        message_instance.send.assert_called_once()
+
+
+def test_get_notification_provider_console(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "console", raising=False)
+
+    provider = get_notification_provider()
+
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+
+def test_get_notification_provider_smtp(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "smtp", raising=False)
+
+    provider = get_notification_provider()
+
+    assert isinstance(provider, SMTPNotificationProvider)


### PR DESCRIPTION
Summary:
- Introduced a simple notifications service to handle all email sending with pluggable providers behind NOTIFICATIONS_PROVIDER.
- Two providers implemented: ConsoleNotificationProvider (logs email details) and SMTPNotificationProvider (sends real emails via configured SMTP).
- Existing email flows (welcome emails, password reset, test email endpoint) are wired to use the new provider, with no frontend changes required.
- Configured via environment variable NOTIFICATIONS_PROVIDER (default: smtp) and exposed in backend Settings for easy switch.

What changed:
- backend/app/notifications.py (added): Defines NotificationProvider interface, ConsoleNotificationProvider, SMTPNotificationProvider, and get_notification_provider() to select provider based on NOTIFICATIONS_PROVIDER. A module-level notification_provider is created for runtime use.
- backend/app/utils.py (modified): Replaced direct email sending with a call to notification_provider.send_email(email_to, subject, html_content).
- backend/app/core/config.py (modified): Added NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp" so provider choice is configurable via env.
- backend/tests/test_notifications.py (added): Tests for Console and SMTP providers and for correct provider selection (console and smtp).
- README updates (backend/README.md, modified): Added a Notifications providers section describing how to switch provider via NOTIFICATIONS_PROVIDER and how it affects existing flows. Guidance to set NOTIFICATIONS_PROVIDER in the .env file and restart the backend.

How to switch provider:
1. Open the .env file (one level above ./backend/).
2. Set NOTIFICATIONS_PROVIDER to one of:
   - NOTIFICATIONS_PROVIDER=smtp to use SMTP provider (requires SMTP configuration).
   - NOTIFICATIONS_PROVIDER=console to log emails to the console instead of sending.
3. Restart the backend to apply changes.

Notes:
- No frontend changes were needed; the UI behavior remains the same.
- All existing email flows automatically use the selected provider.
- README includes guidance on how to switch providers and what each provider does.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/ieu05s4slrk8](https://cosine.sh/cosinedemo/full-stack-demo/task/ieu05s4slrk8)
Author: Des Kramer
