### PR TITLE
Introduce a pluggable notifications service for emails (Console or SMTP) behind NOTIFICATIONS_PROVIDER

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ git merge --continue
 
 You can then update configs in the `.env` files to customize your configurations.
 
+To configure how emails are sent (for example, welcome emails and password reset emails), set the `NOTIFICATIONS_PROVIDER` environment variable in your `.env` files:
+
+- `NOTIFICATIONS_PROVIDER=smtp` (default): send real emails using the configured SMTP settings (`SMTP_HOST`, `SMTP_USER`, etc.).
+- `NOTIFICATIONS_PROVIDER=console`: log email notifications to the backend logs instead of sending them. This is useful for local development when you don't have SMTP configured.
+
 Before deploying it, make sure you change at least the values for:
 
 - `SECRET_KEY`

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):
     EMAILS_FROM_EMAIL: EmailStr | None = None
     EMAILS_FROM_NAME: EmailStr | None = None
 
+    NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
+
     @model_validator(mode="after")
     def _set_default_emails_from(self) -> Self:
         if not self.EMAILS_FROM_NAME:

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,59 @@
+import logging
+from abc import ABC, abstractmethod
+
+from emails import Message  # type: ignore
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationProvider(ABC):
+    @abstractmethod
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class ConsoleNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        logger.info(
+            "ConsoleNotificationProvider: email_to=%s subject=%s html_length=%d",
+            email_to,
+            subject,
+            len(html_content),
+        )
+
+
+class SMTPNotificationProvider(NotificationProvider):
+    def send_email(self, *, email_to: str, subject: str, html_content: str) -> None:
+        if not settings.emails_enabled:
+            raise AssertionError("no provided configuration for email variables")
+
+        message = Message(
+            subject=subject,
+            html=html_content,
+            mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
+        )
+        smtp_options: dict[str, object] = {
+            "host": settings.SMTP_HOST,
+            "port": settings.SMTP_PORT,
+        }
+        if settings.SMTP_TLS:
+            smtp_options["tls"] = True
+        elif settings.SMTP_SSL:
+            smtp_options["ssl"] = True
+        if settings.SMTP_USER:
+            smtp_options["user"] = settings.SMTP_USER
+        if settings.SMTP_PASSWORD:
+            smtp_options["password"] = settings.SMTP_PASSWORD
+        response = message.send(to=email_to, smtp=smtp_options)
+        logger.info("SMTPNotificationProvider send email result: %s", response)
+
+
+def get_notification_provider() -> NotificationProvider:
+    provider_name = settings.NOTIFICATIONS_PROVIDER
+    if provider_name == "console":
+        return ConsoleNotificationProvider()
+    if provider_name == "smtp":
+        return SMTPNotificationProvider()
+    raise ValueError(f"Unknown notifications provider: {provider_name}")

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -4,13 +4,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-import emails  # type: ignore
 import jwt
 from jinja2 import Template
 from jwt.exceptions import InvalidTokenError
 
 from app.core import security
 from app.core.config import settings
+from app.notifications import get_notification_provider
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -36,23 +36,8 @@ def send_email(
     subject: str = "",
     html_content: str = "",
 ) -> None:
-    assert settings.emails_enabled, "no provided configuration for email variables"
-    message = emails.Message(
-        subject=subject,
-        html=html_content,
-        mail_from=(settings.EMAILS_FROM_NAME, settings.EMAILS_FROM_EMAIL),
-    )
-    smtp_options = {"host": settings.SMTP_HOST, "port": settings.SMTP_PORT}
-    if settings.SMTP_TLS:
-        smtp_options["tls"] = True
-    elif settings.SMTP_SSL:
-        smtp_options["ssl"] = True
-    if settings.SMTP_USER:
-        smtp_options["user"] = settings.SMTP_USER
-    if settings.SMTP_PASSWORD:
-        smtp_options["password"] = settings.SMTP_PASSWORD
-    response = message.send(to=email_to, smtp=smtp_options)
-    logger.info(f"send email result: {response}")
+    provider = get_notification_provider()
+    provider.send_email(email_to=email_to, subject=subject, html_content=html_content)
 
 
 def generate_test_email(email_to: str) -> EmailData:

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+import logging
+from _pytest.logging import LogCaptureFixture
+from emails import Message  # type: ignore
+
+from app.core.config import settings
+from app.notifications import (
+    ConsoleNotificationProvider,
+    SMTPNotificationProvider,
+    get_notification_provider,
+)
+
+
+class DummyResponse:
+    def __repr__(self) -> str:  # pragma: no cover - repr not used in assertions
+        return "dummy-response"
+
+
+def test_console_notification_provider_logs(caplog: LogCaptureFixture) -> None:
+    provider = ConsoleNotificationProvider()
+
+    with caplog.at_level(logging.INFO):
+        provider.send_email(
+            email_to="user@example.com",
+            subject="Subject",
+            html_content="<p>Body</p>",
+        )
+
+    assert any(
+        "ConsoleNotificationProvider" in message and "user@example.com" in message
+        for message in caplog.messages
+    )
+
+
+def test_smtp_notification_provider_sends_email(monkeypatch: Any) -> None:
+    sent_args: dict[str, Any] = {}
+
+    def fake_send(self: Message, to: str, smtp: dict[str, Any]) -> DummyResponse:  # type: ignore[override]
+        sent_args["to"] = to
+        sent_args["smtp"] = smtp
+        sent_args["subject"] = self.subject
+        sent_args["html"] = self.html
+        return DummyResponse()
+
+    monkeypatch.setattr(Message, "send", fake_send, raising=False)
+
+    # Ensure settings allow emails
+    settings.SMTP_HOST = "smtp.example.com"
+    settings.EMAILS_FROM_EMAIL = "noreply@example.com"  # type: ignore[assignment]
+
+    provider = SMTPNotificationProvider()
+    provider.send_email(
+        email_to="user@example.com",
+        subject="Subject",
+        html_content="<p>Body</p>",
+    )
+
+    assert sent_args["to"] == "user@example.com"
+    assert sent_args["smtp"]["host"] == "smtp.example.com"
+    assert sent_args["subject"] == "Subject"
+    assert sent_args["html"] == "<p>Body</p>"
+
+
+def test_get_notification_provider_uses_setting(monkeypatch: Any) -> None:
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "console", raising=False)
+    provider = get_notification_provider()
+    assert isinstance(provider, ConsoleNotificationProvider)
+
+    monkeypatch.setattr(settings, "NOTIFICATIONS_PROVIDER", "smtp", raising=False)
+    provider = get_notification_provider()
+    assert isinstance(provider, SMTPNotificationProvider)


### PR DESCRIPTION
Overview
- Adds a pluggable notifications service for sending emails via a provider interface with two concrete implementations: Console (logs) and SMTP (real emails).
- Replaces inline email sending in the backend with a provider-based flow.
- Configured via environment variable NOTIFICATIONS_PROVIDER in settings (default: smtp).
- Frontend behavior remains unchanged; only backend email sending is routed through the new service.

What changed
- backend/app/notifications.py (new)
  - NotificationProvider interface with send_email
  - ConsoleNotificationProvider: logs email sending actions
  - SMTPNotificationProvider: sends real emails using configured SMTP via emails.Message
  - get_notification_provider(): selects provider based on settings.NOTIFICATIONS_PROVIDER
- backend/app/utils.py
  - send_email now delegates to get_notification_provider().send_email(...)
- backend/app/core/config.py
  - Added NOTIFICATIONS_PROVIDER: Literal["console", "smtp"] = "smtp"
- README.md
  - Added guidance on configuring NOTIFICATIONS_PROVIDER with examples:
    - NOTIFICATIONS_PROVIDER=smtp (default): real emails via SMTP settings
    - NOTIFICATIONS_PROVIDER=console: log emails to backend logs
- backend/tests/test_notifications.py (new)
  - Tests for ConsoleNotificationProvider logging
  - Tests for SMTPNotificationProvider email sending via monkeypatching Message.send
  - Tests for get_notification_provider() honoring NOTIFICATIONS_PROVIDER setting

How this solves the task
- Email sends are now routed through a simple, pluggable notifications service with a clear interface and two providers, enabling easy switching between console logging and real SMTP emails.
- The existing flows remain the same from the caller’s perspective; only the internal wiring changed to use the provider, satisfying the requirement to wire existing flows to the new service.
- Configuration via env is added, and README documents how to switch providers, fulfilling the acceptance criteria.

Tests
- Unit tests cover both providers and the provider selection logic to ensure correct behavior across configurations.


---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/wfwfmyv9l0w2](https://cosine.sh/cosinedemo/full-stack-demo/task/wfwfmyv9l0w2)
Author: Des Kramer
