### PR TITLE
Add Auth0 signup proxy endpoint and config, with tests

### DIFF
--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import col, delete, func, select
 
@@ -153,6 +154,56 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     user_create = UserCreate.model_validate(user_in)
     user = crud.create_user(session=session, user_create=user_create)
     return user
+
+
+@router.post("/auth0-signup")
+def auth0_signup(user_in: UserRegister) -> Any:
+    """Proxy sign-up to Auth0's /dbconnections/signup endpoint.
+
+    This creates a new user in Auth0's database connection configured by
+    AUTH0_CONNECTION. It does **not** create a local user in this service.
+    """
+
+    if not settings.AUTH0_DOMAIN or not settings.AUTH0_CLIENT_ID:
+        raise HTTPException(
+            status_code=500,
+            detail="Auth0 is not configured. Please set AUTH0_DOMAIN and AUTH0_CLIENT_ID.",
+        )
+
+    payload: dict[str, Any] = {
+        "client_id": settings.AUTH0_CLIENT_ID,
+        "email": user_in.email,
+        "password": user_in.password,
+        "connection": settings.AUTH0_CONNECTION,
+    }
+
+    if user_in.full_name:
+        payload["name"] = user_in.full_name
+
+    url = f"https://{settings.AUTH0_DOMAIN}/dbconnections/signup"
+
+    try:
+        response = httpx.post(url, json=payload, timeout=10.0)
+    except httpx.RequestError:
+        raise HTTPException(
+            status_code=502,
+            detail="Error communicating with Auth0 signup API.",
+        )
+
+    # Auth0 returns 200 on success; on error it still returns JSON with an "error" key.
+    if response.status_code not in (200, 201):
+        # Try to surface Auth0's error message to the client.
+        try:
+            error_body = response.json()
+        except ValueError:  # response is not JSON
+            error_body = {"message": response.text}
+        raise HTTPException(status_code=response.status_code, detail=error_body)
+
+    try:
+        return response.json()
+    except ValueError:
+        # Should not happen for Auth0, but guard just in case.
+        return {"message": "User created in Auth0, but response was not JSON."}
 
 
 @router.get("/{user_id}", response_model=UserPublic)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -94,6 +94,11 @@ class Settings(BaseSettings):
     FIRST_SUPERUSER: EmailStr
     FIRST_SUPERUSER_PASSWORD: str
 
+    # Auth0 configuration for signup via Authentication API
+    AUTH0_DOMAIN: str | None = None
+    AUTH0_CLIENT_ID: str | None = None
+    AUTH0_CONNECTION: str = "Username-Password-Authentication"
+
     def _check_default_secret(self, var_name: str, value: str | None) -> None:
         if value == "changethis":
             message = (

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+from httpx import Response
 from sqlmodel import Session, select
 
 from app import crud
@@ -318,6 +319,258 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
     )
     assert r.status_code == 400
     assert r.json()["detail"] == "The user with this email already exists in the system"
+
+
+def test_auth0_signup(client: TestClient) -> None:
+    username = random_email()
+    password = random_lower_string()
+    full_name = random_lower_string()
+    data = {"email": username, "password": password, "full_name": full_name}
+
+    with (
+        patch("app.core.config.settings.AUTH0_DOMAIN", "example.auth0.com"),
+        patch("app.core.config.settings.AUTH0_CLIENT_ID", "test-client-id"),
+        patch("httpx.post") as mock_post,
+    ):
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"_id": "auth0|123", "email": username},  # type: ignore[arg-type]
+        )
+
+        r = client.post(
+            f"{settings.API_V1_STR}/users/auth0-signup",
+            json=data,
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["email"] == username
+    assert body["_id"] == "auth0|123"
+
+
+def test_update_user(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+
+    data = {"full_name": "Updated_full_name"}
+    r = client.patch(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        headers=superuser_token_headers,
+        json=data,
+    )
+    assert r.status_code == 200
+    updated_user = r.json()
+
+    assert updated_user["full_name"] == "Updated_full_name"
+
+    user_query = select(User).where(User.email == username)
+    user_db = db.exec(user_query).first()
+    db.refresh(user_db)
+    assert user_db
+    assert user_db.full_name == "Updated_full_name"
+
+
+def test_update_user_not_exists(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    data = {"full_name": "Updated_full_name"}
+    r = client.patch(
+        f"{settings.API_V1_STR}/users/{uuid.uuid4()}",
+        headers=superuser_token_headers,
+        json=data,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "The user with this id does not exist in the system"
+
+
+def test_update_user_email_exists(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+
+    username2 = random_email()
+    password2 = random_lower_string()
+    user_in2 = UserCreate(email=username2, password=password2)
+    user2 = crud.create_user(session=db, user_create=user_in2)
+
+    data = {"email": user2.email}
+    r = client.patch(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        headers=superuser_token_headers,
+        json=data,
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"] == "User with this email already exists"
+
+
+def test_delete_user_me(client: TestClient, db: Session) -> None:
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    user_id = user.id
+
+    login_data = {
+        "username": username,
+        "password": password,
+    }
+    r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
+    tokens = r.json()
+    a_token = tokens["access_token"]
+    headers = {"Authorization": f"Bearer {a_token}"}
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/me",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    deleted_user = r.json()
+    assert deleted_user["message"] == "User deleted successfully"
+    result = db.exec(select(User).where(User.id == user_id)).first()
+    assert result is None
+
+    user_query = select(User).where(User.id == user_id)
+    user_db = db.execute(user_query).first()
+    assert user_db is None
+
+
+def test_delete_user_me_as_superuser(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/me",
+        headers=superuser_token_headers,
+    )
+    assert r.status_code == 403
+    response = r.json()
+    assert response["detail"] == "Super users are not allowed to delete themselves"
+
+
+def test_delete_user_super_user(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+    user_id = user.id
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=superuser_token_headers,
+    )
+    assert r.status_code == 200
+    deleted_user = r.json()
+    assert deleted_user["message"] == "User deleted successfully"
+    result = db.exec(select(User).where(User.id == user_id)).first()
+    assert result is None
+
+
+def test_delete_user_not_found(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/{uuid.uuid4()}",
+        headers=superuser_token_headers,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"] == "User not found"
+
+
+def test_delete_user_current_super_user_error(
+    client: TestClient, superuser_token_headers: dict[str, str], db: Session
+) -> None:
+    super_user = crud.get_user_by_email(session=db, email=settings.FIRST_SUPERUSER)
+    assert super_user
+    user_id = super_user.id
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/{user_id}",
+        headers=superuser_token_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "Super users are not allowed to delete themselves"
+
+
+def test_delete_user_without_privileges(
+    client: TestClient, normal_user_token_headers: dict[str, str], db: Session
+) -> None:
+    username = random_email()
+    password = random_lower_string()
+    user_in = UserCreate(email=username, password=password)
+    user = crud.create_user(session=db, user_create=user_in)
+
+    r = client.delete(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        headers=normal_user_token_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"] == "The user doesn't have enough privileges"client: TestClient, db: Session) -> None:
+    username = random_email()
+    password = random_lower_string()
+    full_name = random_lower_string()
+    data = {"email": username, "password": password, "full_name": full_name}
+    r = client.post(
+        f"{settings.API_V1_STR}/users/signup",
+        json=data,
+    )
+    assert r.status_code == 200
+    created_user = r.json()
+    assert created_user["email"] == username
+    assert created_user["full_name"] == full_name
+
+    user_query = select(User).where(User.email == username)
+    user_db = db.exec(user_query).first()
+    assert user_db
+    assert user_db.email == username
+    assert user_db.full_name == full_name
+    assert verify_password(password, user_d</old_code><new_code>def test_register_user_already_exists_error(client: TestClient) -> None:
+    password = random_lower_string()
+    full_name = random_lower_string()
+    data = {
+        "email": settings.FIRST_SUPERUSER,
+        "password": password,
+        "full_name": full_name,
+    }
+    r = client.post(
+        f"{settings.API_V1_STR}/users/signup",
+        json=data,
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "The user with this email already exists in the system"
+
+
+def test_auth0_signup(client: TestClient) -> None:
+    username = random_email()
+    password = random_lower_string()
+    full_name = random_lower_string()
+    data = {"email": username, "password": password, "full_name": full_name}
+
+    with (
+        patch("app.core.config.settings.AUTH0_DOMAIN", "example.auth0.com"),
+        patch("app.core.config.settings.AUTH0_CLIENT_ID", "test-client-id"),
+        patch("httpx.post") as mock_post,
+    ):
+        mock_post.return_value = Response(
+            status_code=200,
+            json={"_id": "auth0|123", "email": username},  # type: ignore[arg-type]
+        )
+
+        r = client.post(
+            f"{settings.API_V1_STR}/users/auth0-signup",
+            json=data,
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["email"] == username
+    assert body["_id"] == "auth0|123"
 
 
 def test_update_user(


### PR DESCRIPTION
Implemented a new Auth0 signup proxy endpoint and related configuration to sign up users directly to Auth0 without creating a local user.

What changed:
- Added POST /auth0-signup in backend/app/api/routes/users.py that proxies signup requests to Auth0's /dbconnections/signup API.
  - Validates Auth0 configuration (AUTH0_DOMAIN and AUTH0_CLIENT_ID); returns 500 if missing.
  - Sends payload including email, password, connection, and optional name (full_name).
  - Uses the configured AUTH0_CONNECTION (default: Username-Password-Authentication).
  - On success, returns Auth0's JSON response. On error, surfaces Auth0 error messages and status codes. Handles request errors with 502.
  - This path does not create a local user in the service; signups go directly to Auth0.
- Extended configuration in backend/app/core/config.py:
  - Added AUTH0_DOMAIN: str | None
  - Added AUTH0_CLIENT_ID: str | None
  - Added AUTH0_CONNECTION: str = "Username-Password-Authentication"
- Tests:
  - Added test_auth0_signup in backend/tests/api/routes/test_users.py to verify the /auth0-signup flow.
  - Test mocks Auth0 domain/client_id via patch and simulates a successful Auth0 response from httpx.post.
  - Test validates that the API returns the Auth0 payload (e.g., email and _id).

Notes:
- This feature enables integrating with Auth0 for user signup. It does not affect existing local user signup flow.
- Tests mock external calls to avoid real network access and patch configuration for isolation.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/xaxarm4m5kn9](https://cosine.sh/cosinedemo/full-stack-demo/task/xaxarm4m5kn9)
Author: Des Kramer
