### PR TITLE
Add a lighthearted joke to README after License

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,7 @@ Check the file [release-notes.md](./release-notes.md).
 ## License
 
 The Full Stack FastAPI Template is licensed under the terms of the MIT license.
+
+---
+
+_And yes, it’s a "full stack" template — because "half stack" just sounded like a very confused pancake order._


### PR DESCRIPTION
Adds a small joke to the README to give readers a friendly touch. Inserts a horizontal rule and an italicized joke after the License section:

---

_And yes, it’s a "full stack" template — because "half stack" just sounded like a very confused pancake order._

This change does not affect functionality; it's strictly README content.

---

> This pull request was co-created with Cosine Genie

Original Task: [full-stack-demo/qpj2zeyjk7w5](https://cosine.sh/cosinedemo/full-stack-demo/task/qpj2zeyjk7w5)
Author: James White
