### PR TITLE
feat: add username support and unify signup conflicts to 409 with inline UI errors

### DIFF
--- a/backend/app/alembic/versions/2b7c5b3e1f0d_add_username_to_user.py
+++ b/backend/app/alembic/versions/2b7c5b3e1f0d_add_username_to_user.py
@@ -1,0 +1,33 @@
+"""Add username to user
+
+Revision ID: 2b7c5b3e1f0d
+Revises: 1a31ce608336
+Create Date: 2026-02-18
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision = "2b7c5b3e1f0d"
+down_revision = "1a31ce608336"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "user",
+        sa.Column("username", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.execute('UPDATE "user" SET username = email WHERE username IS NULL')
+    op.alter_column("user", "username", nullable=False)
+    op.create_index(op.f("ix_user_username"), "user", ["username"], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_user_username"), table_name="user")
+    op.drop_column("user", "username")

--- a/backend/app/api/routes/private.py
+++ b/backend/app/api/routes/private.py
@@ -28,6 +28,7 @@ def create_user(user_in: PrivateUserCreate, session: SessionDep) -> Any:
 
     user = User(
         email=user_in.email,
+        username=user_in.email,
         full_name=user_in.full_name,
         hashed_password=get_password_hash(user_in.password),
     )

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -2,6 +2,8 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, delete, func, select
 
 from app import crud
@@ -29,6 +31,9 @@ from app.utils import generate_new_account_email, send_email
 router = APIRouter(prefix="/users", tags=["users"])
 
 
+def conflict_response(field: str) -> JSONResponse:
+    return JSONResponse(status_code=409, content={"error": "conflict", "field": field})
+
 @router.get(
     "/",
     dependencies=[Depends(get_current_active_superuser)],
@@ -49,9 +54,7 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 
 
 @router.post(
-    "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
-)
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+    "/", dependencies=[Depends(get_current_active_superuser)], respons</old_code><new_code>def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
     """
     Create new user.
     """
@@ -62,10 +65,17 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
             detail="The user with this email already exists in the system.",
         )
 
+    user = crud.get_user_by_username(session=session, username=user_in.username)
+    if user:
+        raise HTTPException(
+            status_code=400,
+            detail="The user with this username already exists in the system.",
+        )
+
     user = crud.create_user(session=session, user_create=user_in)
     if settings.emails_enabled and user_in.email:
         email_data = generate_new_account_email(
-            email_to=user_in.email, username=user_in.email, password=user_in.password
+            email_to=user_in.email, username=user_in.username, password=user_in.password
         )
         send_email(
             email_to=user_in.email,
@@ -136,22 +146,31 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
         )
     session.delete(current_user)
     session.commit()
-    return Message(message="User deleted successfully")
-
-
-@router.post("/signup", response_model=UserPublic)
+    return Message(message="User dele</old_code><new_code>@router.post("/signup", response_model=UserPublic)
 def register_user(session: SessionDep, user_in: UserRegister) -> Any:
     """
     Create new user without the need to be logged in.
     """
     user = crud.get_user_by_email(session=session, email=user_in.email)
     if user:
-        raise HTTPException(
-            status_code=400,
-            detail="The user with this email already exists in the system",
-        )
+        return conflict_response("email")
+
+    user = crud.get_user_by_username(session=session, username=user_in.username)
+    if user:
+        return conflict_response("username")
+
     user_create = UserCreate.model_validate(user_in)
-    user = crud.create_user(session=session, user_create=user_create)
+    try:
+        user = crud.create_user(session=session, user_create=user_create)
+    except IntegrityError as e:
+        session.rollback()
+        error_text = str(getattr(e, "orig", e)).lower()
+        if "username" in error_text:
+            return conflict_response("username")
+        if "email" in error_text:
+            return conflict_response("email")
+        raise
+
     return user
 
 

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -27,6 +27,7 @@ def init_db(session: Session) -> None:
     if not user:
         user_in = UserCreate(
             email=settings.FIRST_SUPERUSER,
+            username=settings.FIRST_SUPERUSER,
             password=settings.FIRST_SUPERUSER_PASSWORD,
             is_superuser=True,
         )

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -37,6 +37,12 @@ def get_user_by_email(*, session: Session, email: str) -> User | None:
     return session_user
 
 
+def get_user_by_username(*, session: Session, username: str) -> User | None:
+    statement = select(User).where(User.username == username)
+    session_user = session.exec(statement).first()
+    return session_user
+
+
 def authenticate(*, session: Session, email: str, password: str) -> User | None:
     db_user = get_user_by_email(session=session, email=email)
     if not db_user:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -7,6 +7,7 @@ from sqlmodel import Field, Relationship, SQLModel
 # Shared properties
 class UserBase(SQLModel):
     email: EmailStr = Field(unique=True, index=True, max_length=255)
+    username: str = Field(unique=True, index=True, max_length=255)
     is_active: bool = True
     is_superuser: bool = False
     full_name: str | None = Field(default=None, max_length=255)
@@ -19,19 +20,22 @@ class UserCreate(UserBase):
 
 class UserRegister(SQLModel):
     email: EmailStr = Field(max_length=255)
+    username: str = Field(max_length=255)
     password: str = Field(min_length=8, max_length=40)
+    full_name: str | None = Field(default=Non</old_code><new_code># Properties to receive via API on update, all are optional
+class UserUpdate(SQLModel):
+    email: EmailStr | None = Field(default=None, max_length=255)
+    username: str | None = Field(default=None, max_length=255)
+    is_active: bool | None = None
+    is_superuser: bool | None = None
     full_name: str | None = Field(default=None, max_length=255)
-
-
-# Properties to receive via API on update, all are optional
-class UserUpdate(UserBase):
-    email: EmailStr | None = Field(default=None, max_length=255)  # type: ignore
     password: str | None = Field(default=None, min_length=8, max_length=40)
 
 
 class UserUpdateMe(SQLModel):
     full_name: str | None = Field(default=None, max_length=255)
     email: EmailStr | None = Field(default=None, max_length=255)
+    username: str | None = Field(default=None, max_length=255)
 
 
 class UpdatePassword(SQLModel):

--- a/backend/tests/api/routes/test_login.py
+++ b/backend/tests/api/routes/test_login.py
@@ -79,6 +79,7 @@ def test_reset_password(client: TestClient, db: Session) -> None:
 
     user_create = UserCreate(
         email=email,
+        username=email,
         full_name="Test User",
         password=password,
         is_active=True,

--- a/backend/tests/api/routes/test_users.py
+++ b/backend/tests/api/routes/test_users.py
@@ -41,9 +41,9 @@ def test_create_user_new_email(
         patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
         patch("app.core.config.settings.SMTP_USER", "admin@example.com"),
     ):
-        username = random_email()
+        email = random_email()
         password = random_lower_string()
-        data = {"email": username, "password": password}
+        data = {"email": email, "username": random_lower_string(), "password": password}
         r = client.post(
             f"{settings.API_V1_STR}/users/",
             headers=superuser_token_headers,
@@ -51,7 +51,7 @@ def test_create_user_new_email(
         )
         assert 200 <= r.status_code < 300
         created_user = r.json()
-        user = crud.get_user_by_email(session=db, email=username)
+        user = crud.get_user_by_email(session=db, email=email)
         assert user
         assert user.email == created_user["email"]
 
@@ -59,9 +59,9 @@ def test_create_user_new_email(
 def test_get_existing_user(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     user_id = user.id
     r = client.get(
@@ -70,20 +70,20 @@ def test_get_existing_user(
     )
     assert 200 <= r.status_code < 300
     api_user = r.json()
-    existing_user = crud.get_user_by_email(session=db, email=username)
+    existing_user = crud.get_user_by_email(session=db, email=email)
     assert existing_user
     assert existing_user.email == api_user["email"]
 
 
 def test_get_existing_user_current_user(client: TestClient, db: Session) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     user_id = user.id
 
     login_data = {
-        "username": username,
+        "username": email,
         "password": password,
     }
     r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
@@ -97,7 +97,7 @@ def test_get_existing_user_current_user(client: TestClient, db: Session) -> None
     )
     assert 200 <= r.status_code < 300
     api_user = r.json()
-    existing_user = crud.get_user_by_email(session=db, email=username)
+    existing_user = crud.get_user_by_email(session=db, email=email)
     assert existing_user
     assert existing_user.email == api_user["email"]
 
@@ -116,12 +116,11 @@ def test_get_existing_user_permissions_error(
 def test_create_user_existing_username(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
-    # username = email
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     crud.create_user(session=db, user_create=user_in)
-    data = {"email": username, "password": password}
+    data = {"email": email, "username": random_lower_string(), "password": password}
     r = client.post(
         f"{settings.API_V1_STR}/users/",
         headers=superuser_token_headers,
@@ -135,9 +134,9 @@ def test_create_user_existing_username(
 def test_create_user_by_normal_user(
     client: TestClient, normal_user_token_headers: dict[str, str]
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    data = {"email": username, "password": password}
+    data = {"email": email, "username": random_lower_string(), "password": password}
     r = client.post(
         f"{settings.API_V1_STR}/users/",
         headers=normal_user_token_headers,
@@ -149,14 +148,14 @@ def test_create_user_by_normal_user(
 def test_retrieve_users(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
-    password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    email1 = random_email()
+    password1 = random_lower_string()
+    user_in = UserCreate(email=email1, username=email1, password=password1)
     crud.create_user(session=db, user_create=user_in)
 
-    username2 = random_email()
+    email2 = random_email()
     password2 = random_lower_string()
-    user_in2 = UserCreate(email=username2, password=password2)
+    user_in2 = UserCreate(email=email2, username=email2, password=password2)
     crud.create_user(session=db, user_create=user_in2)
 
     r = client.get(f"{settings.API_V1_STR}/users/", headers=superuser_token_headers)
@@ -248,9 +247,9 @@ def test_update_password_me_incorrect_password(
 def test_update_user_me_email_exists(
     client: TestClient, normal_user_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
 
     data = {"email": user.email}
@@ -283,32 +282,13 @@ def test_update_password_me_same_password_error(
 
 
 def test_register_user(client: TestClient, db: Session) -> None:
-    username = random_email()
-    password = random_lower_string()
-    full_name = random_lower_string()
-    data = {"email": username, "password": password, "full_name": full_name}
-    r = client.post(
-        f"{settings.API_V1_STR}/users/signup",
-        json=data,
-    )
-    assert r.status_code == 200
-    created_user = r.json()
-    assert created_user["email"] == username
-    assert created_user["full_name"] == full_name
-
-    user_query = select(User).where(User.email == username)
-    user_db = db.exec(user_query).first()
-    assert user_db
-    assert user_db.email == username
-    assert user_db.full_name == full_name
-    assert verify_password(password, user_db.hashed_password)
-
-
-def test_register_user_already_exists_error(client: TestClient) -> None:
+    email = random_email()
+    username = random_lower_string()
     password = random_lower_string()
     full_name = random_lower_string()
     data = {
-        "email": settings.FIRST_SUPERUSER,
+        "email": email,
+        "username": username,
         "password": password,
         "full_name": full_name,
     }
@@ -316,16 +296,57 @@ def test_register_user_already_exists_error(client: TestClient) -> None:
         f"{settings.API_V1_STR}/users/signup",
         json=data,
     )
-    assert r.status_code == 400
-    assert r.json()["detail"] == "The user with this email already exists in the system"
+    assert r.status_code == 200
+    created_user = r.json()
+    assert created_user["email"] == email
+    assert created_user["username"] == username
+    assert created_user["full_name"] == full_name
+
+    user_query = select(User).where(User.email == email)
+    user_db = db.exec(user_query).first()
+    assert user_db
+    assert user_db.email == email
+    assert user_db.username == username
+    assert user_db.full_name == full_name
+    assert verify_password(password, user_db.hashed_password)
+
+
+def test_register_user_duplicate_email_returns_conflict(client: TestClient) -> None:
+    data = {
+        "email": settings.FIRST_SUPERUSER,
+        "username": random_lower_string(),
+        "password": random_lower_string(),
+        "full_name": random_lower_string(),
+    }
+    r = client.post(
+        f"{settings.API_V1_STR}/users/signup",
+        json=data,
+    )
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "email"}
+
+
+def test_register_user_duplicate_username_returns_conflict(client: TestClient) -> None:
+    data = {
+        "email": random_email(),
+        "username": settings.FIRST_SUPERUSER,
+        "password": random_lower_string(),
+        "full_name": random_lower_string(),
+    }
+    r = client.post(
+        f"{settings.API_V1_STR}/users/signup",
+        json=data,
+    )
+    assert r.status_code == 409
+    assert r.json() == {"error": "conflict", "field": "username"}
 
 
 def test_update_user(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
 
     data = {"full_name": "Updated_full_name"}
@@ -339,7 +360,7 @@ def test_update_user(
 
     assert updated_user["full_name"] == "Updated_full_name"
 
-    user_query = select(User).where(User.email == username)
+    user_query = select(User).where(User.email == email)
     user_db = db.exec(user_query).first()
     db.refresh(user_db)
     assert user_db
@@ -362,14 +383,14 @@ def test_update_user_not_exists(
 def test_update_user_email_exists(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
-    password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    email1 = random_email()
+    password1 = random_lower_string()
+    user_in = UserCreate(email=email1, username=email1, password=password1)
     user = crud.create_user(session=db, user_create=user_in)
 
-    username2 = random_email()
+    email2 = random_email()
     password2 = random_lower_string()
-    user_in2 = UserCreate(email=username2, password=password2)
+    user_in2 = UserCreate(email=email2, username=email2, password=password2)
     user2 = crud.create_user(session=db, user_create=user_in2)
 
     data = {"email": user2.email}
@@ -383,14 +404,14 @@ def test_update_user_email_exists(
 
 
 def test_delete_user_me(client: TestClient, db: Session) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     user_id = user.id
 
     login_data = {
-        "username": username,
+        "username": email,
         "password": password,
     }
     r = client.post(f"{settings.API_V1_STR}/login/access-token", data=login_data)
@@ -428,9 +449,9 @@ def test_delete_user_me_as_superuser(
 def test_delete_user_super_user(
     client: TestClient, superuser_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     user_id = user.id
     r = client.delete(
@@ -473,9 +494,9 @@ def test_delete_user_current_super_user_error(
 def test_delete_user_without_privileges(
     client: TestClient, normal_user_token_headers: dict[str, str], db: Session
 ) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
 
     r = client.delete(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,7 @@ def override_get_current_user() -> User:
     return User(
         id=MOCK_USER_PUBLIC_1.id,
         email=MOCK_USER_PUBLIC_1.email,
+        username=MOCK_USER_PUBLIC_1.email,
         is_active=MOCK_USER_PUBLIC_1.is_active,
         is_superuser=True,
         full_name=MOCK_USER_PUBLIC_1.full_name,

--- a/backend/tests/crud/test_user.py
+++ b/backend/tests/crud/test_user.py
@@ -10,7 +10,7 @@ from tests.utils.utils import random_email, random_lower_string
 def test_create_user(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     assert user.email == email
     assert hasattr(user, "hashed_password")
@@ -19,7 +19,7 @@ def test_create_user(db: Session) -> None:
 def test_authenticate_user(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     authenticated_user = crud.authenticate(session=db, email=email, password=password)
     assert authenticated_user
@@ -36,7 +36,7 @@ def test_not_authenticate_user(db: Session) -> None:
 def test_check_if_user_is_active(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     assert user.is_active is True
 
@@ -44,31 +44,31 @@ def test_check_if_user_is_active(db: Session) -> None:
 def test_check_if_user_is_active_inactive(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password, disabled=True)
+    user_in = UserCreate(email=email, username=email, password=password, is_active=False)
     user = crud.create_user(session=db, user_create=user_in)
-    assert user.is_active
+    assert not user.is_active
 
 
 def test_check_if_user_is_superuser(db: Session) -> None:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password, is_superuser=True)
+    user_in = UserCreate(email=email, username=email, password=password, is_superuser=True)
     user = crud.create_user(session=db, user_create=user_in)
     assert user.is_superuser is True
 
 
 def test_check_if_user_is_superuser_normal_user(db: Session) -> None:
-    username = random_email()
+    email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=username, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     assert user.is_superuser is False
 
 
 def test_get_user(db: Session) -> None:
     password = random_lower_string()
-    username = random_email()
-    user_in = UserCreate(email=username, password=password, is_superuser=True)
+    email = random_email()
+    user_in = UserCreate(email=email, username=email, password=password, is_superuser=True)
     user = crud.create_user(session=db, user_create=user_in)
     user_2 = db.get(User, user.id)
     assert user_2
@@ -79,7 +79,7 @@ def test_get_user(db: Session) -> None:
 def test_update_user(db: Session) -> None:
     password = random_lower_string()
     email = random_email()
-    user_in = UserCreate(email=email, password=password, is_superuser=True)
+    user_in = UserCreate(email=email, username=email, password=password, is_superuser=True)
     user = crud.create_user(session=db, user_create=user_in)
     new_password = random_lower_string()
     user_in_update = UserUpdate(password=new_password, is_superuser=True)

--- a/backend/tests/mock_data.py
+++ b/backend/tests/mock_data.py
@@ -18,12 +18,14 @@ TEST_USER_ID_2 = uuid4()
 
 MOCK_USER_CREATE_1 = UserCreate(
     email="alice@example.com",
+    username="alice",
     password="strongpassword1",
     full_name="Alice Example",
 )
 
 MOCK_USER_CREATE_2 = UserCreate(
     email="bob@example.com",
+    username="bob",
     password="strongpassword2",
     full_name="Bob Example",
 )
@@ -35,6 +37,7 @@ MOCK_USER_UPDATE_1 = UserUpdate(
 MOCK_USER_PUBLIC_1 = UserPublic(
     id=TEST_USER_ID_1,
     email="alice@example.com",
+    username="alice",
     is_active=True,
     is_superuser=False,
     full_name="Alice Example",
@@ -43,6 +46,7 @@ MOCK_USER_PUBLIC_1 = UserPublic(
 MOCK_USER_PUBLIC_2 = UserPublic(
     id=TEST_USER_ID_2,
     email="bob@example.com",
+    username="bob",
     is_active=True,
     is_superuser=False,
     full_name="Bob Example",

--- a/backend/tests/utils/user.py
+++ b/backend/tests/utils/user.py
@@ -22,7 +22,7 @@ def user_authentication_headers(
 def create_random_user(db: Session) -> User:
     email = random_email()
     password = random_lower_string()
-    user_in = UserCreate(email=email, password=password)
+    user_in = UserCreate(email=email, username=email, password=password)
     user = crud.create_user(session=db, user_create=user_in)
     return user
 
@@ -38,7 +38,7 @@ def authentication_token_from_email(
     password = random_lower_string()
     user = crud.get_user_by_email(session=db, email=email)
     if not user:
-        user_in_create = UserCreate(email=email, password=password)
+        user_in_create = UserCreate(email=email, username=email, password=password)
         user = crud.create_user(session=db, user_create=user_in_create)
     else:
         user_in_update = UserUpdate(password=password)

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -282,6 +282,11 @@ export const UserCreateSchema = {
             format: 'email',
             title: 'Email'
         },
+        username: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Username'
+        },
         is_active: {
             type: 'boolean',
             title: 'Is Active',
@@ -312,7 +317,7 @@ export const UserCreateSchema = {
         }
     },
     type: 'object',
-    required: ['email', 'password'],
+    required: ['email', 'username', 'password'],
     title: 'UserCreate'
 } as const;
 
@@ -323,6 +328,11 @@ export const UserPublicSchema = {
             maxLength: 255,
             format: 'email',
             title: 'Email'
+        },
+        username: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Username'
         },
         is_active: {
             type: 'boolean',
@@ -353,7 +363,7 @@ export const UserPublicSchema = {
         }
     },
     type: 'object',
-    required: ['email', 'id'],
+    required: ['email', 'username', 'id'],
     title: 'UserPublic'
 } as const;
 
@@ -364,6 +374,11 @@ export const UserRegisterSchema = {
             maxLength: 255,
             format: 'email',
             title: 'Email'
+        },
+        username: {
+            type: 'string',
+            maxLength: 255,
+            title: 'Username'
         },
         password: {
             type: 'string',
@@ -385,7 +400,7 @@ export const UserRegisterSchema = {
         }
     },
     type: 'object',
-    required: ['email', 'password'],
+    required: ['email', 'username', 'password'],
     title: 'UserRegister'
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -63,6 +63,7 @@ export type UpdatePassword = {
 
 export type UserCreate = {
     email: string;
+    username: string;
     is_active?: boolean;
     is_superuser?: boolean;
     full_name?: (string | null);
@@ -71,6 +72,7 @@ export type UserCreate = {
 
 export type UserPublic = {
     email: string;
+    username: string;
     is_active?: boolean;
     is_superuser?: boolean;
     full_name?: (string | null);
@@ -79,6 +81,7 @@ export type UserPublic = {
 
 export type UserRegister = {
     email: string;
+    username: string;
     password: string;
     full_name?: (string | null);
 };

--- a/frontend/src/components/Admin/AddUser.tsx
+++ b/frontend/src/components/Admin/AddUser.tsx
@@ -47,6 +47,7 @@ const AddUser = () => {
     criteriaMode: "all",
     defaultValues: {
       email: "",
+      username: "",
       full_name: "",
       password: "",
       confirm_password: "",
@@ -111,6 +112,21 @@ const AddUser = () => {
                   })}
                   placeholder="Email"
                   type="email"
+                />
+              </Field>
+
+              <Field
+                required
+                invalid={!!errors.username}
+                errorText={errors.username?.message}
+                label="Username"
+              >
+                <Input
+                  {...register("username", {
+                    required: "Username is required",
+                  })}
+                  placeholder="Username"
+                  type="text"
                 />
               </Field>
 

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -37,12 +37,14 @@ function SignUp() {
     register,
     handleSubmit,
     getValues,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<UserRegisterForm>({
     mode: "onBlur",
     criteriaMode: "all",
     defaultValues: {
       email: "",
+      username: "",
       full_name: "",
       password: "",
       confirm_password: "",
@@ -50,7 +52,22 @@ function SignUp() {
   })
 
   const onSubmit: SubmitHandler<UserRegisterForm> = (data) => {
-    signUpMutation.mutate(data)
+    signUpMutation.mutate(data, {
+      onError: (err) => {
+        const body = (err as any)?.body
+        if ((err as any)?.status === 409 && body?.error === "conflict") {
+          const field = body?.field
+          const message =
+            field === "email"
+              ? "Email already exists"
+              : field === "username"
+                ? "Username already exists"
+                : "Already exists"
+
+          setError(field as any, { message })
+        }
+      },
+    })
   }
 
   return (
@@ -84,6 +101,19 @@ function SignUp() {
                 required: "Full Name is required",
               })}
               placeholder="Full Name"
+              type="text"
+            />
+          </InputGroup>
+        </Field>
+
+        <Field invalid={!!errors.username} errorText={errors.username?.message}>
+          <InputGroup w="100%" startElement={<FiUser />}>
+            <Input
+              minLength={3}
+              {...register("username", {
+                required: "Username is required",
+              })}
+              placeholder="Username"
               type="text"
             />
           </InputGroup>

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -45,8 +45,15 @@ export const confirmPasswordRules = (
 }
 
 export const handleError = (err: ApiError) => {
+  const body = err.body as any
+
+  // Let forms handle inline conflict errors
+  if (err.status === 409 && body?.error === "conflict") {
+    return
+  }
+
   const { showErrorToast } = useCustomToast()
-  const errDetail = (err.body as any)?.detail
+  const errDetail = body?.detail
   let errorMessage = errDetail || "Something went wrong."
   if (Array.isArray(errDetail) && errDetail.length > 0) {
     errorMessage = errDetail[0].msg

--- a/frontend/tests/sign-up.spec.ts
+++ b/frontend/tests/sign-up.spec.ts
@@ -11,11 +11,13 @@ type OptionsType = {
 const fillForm = async (
   page: Page,
   full_name: string,
+  username: string,
   email: string,
   password: string,
   confirm_password: string,
 ) => {
   await page.getByPlaceholder("Full Name").fill(full_name)
+  await page.getByPlaceholder("Username").fill(username)
   await page.getByPlaceholder("Email").fill(email)
   await page.getByPlaceholder("Password", { exact: true }).fill(password)
   await page.getByPlaceholder("Confirm Password").fill(confirm_password)
@@ -36,6 +38,7 @@ test("Inputs are visible, empty and editable", async ({ page }) => {
   await page.goto("/signup")
 
   await verifyInput(page, "Full Name")
+  await verifyInput(page, "Username")
   await verifyInput(page, "Email")
   await verifyInput(page, "Password", { exact: true })
   await verifyInput(page, "Confirm Password")
@@ -53,13 +56,14 @@ test("Log In link is visible", async ({ page }) => {
   await expect(page.getByRole("link", { name: "Log In" })).toBeVisible()
 })
 
-test("Sign up with valid name, email, and password", async ({ page }) => {
+test("Sign up with valid name, username, email, and password", async ({ page }) => {
   const full_name = "Test User"
+  const username = "testuser"
   const email = randomEmail()
   const password = randomPassword()
 
   await page.goto("/signup")
-  await fillForm(page, full_name, email, password, password)
+  await fillForm(page, full_name, username, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 })
 
@@ -69,6 +73,7 @@ test("Sign up with invalid email", async ({ page }) => {
   await fillForm(
     page,
     "Playwright Test",
+    "playwright",
     "invalid-email",
     "changethis",
     "changethis",
@@ -80,89 +85,112 @@ test("Sign up with invalid email", async ({ page }) => {
 
 test("Sign up with existing email", async ({ page }) => {
   const fullName = "Test User"
+  const username = `user_${Math.random().toString(36).substring(2)}`
   const email = randomEmail()
   const password = randomPassword()
 
   // Sign up with an email
   await page.goto("/signup")
-
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, fullName, username, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
   // Sign up again with the same email
   await page.goto("/signup")
-
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, fullName, `${username}_2`, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await page
-    .getByText("The user with this email already exists in the system")
-    .click()
+  await expect(page.getByText("Email already exists")).toBeVisible()
+})
+
+test("Sign up with existing username", async ({ page }) => {
+  const fullName = "Test User"
+  const username = `user_${Math.random().toString(36).substring(2)}`
+  const email = randomEmail()
+  const password = randomPassword()
+
+  await page.goto("/signup")
+  await fillForm(page, fullName, username, email, password, password)
+  await page.getByRole("button", { name: "Sign Up" }).click()
+
+  await page.goto("/signup")
+  await fillForm(page, fullName, username, randomEmail(), password, password)
+  await page.getByRole("button", { name: "Sign Up" }).click()
+
+  await expect(page.getByText("Username already exists")).toBeVisible()
 })
 
 test("Sign up with weak password", async ({ page }) => {
   const fullName = "Test User"
+  const username = `user_${Math.random().toString(36).substring(2)}`
   const email = randomEmail()
   const password = "weak"
 
   await page.goto("/signup")
 
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, fullName, username, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
   await expect(
     page.getByText("Password must be at least 8 characters"),
-  ).toBeVisible()
-})
-
-test("Sign up with mismatched passwords", async ({ page }) => {
+ </old_code><new_code>test("Sign up with mismatched passwords", async ({ page }) => {
   const fullName = "Test User"
+  const username = `user_${Math.random().toString(36).substring(2)}`
   const email = randomEmail()
   const password = randomPassword()
   const password2 = randomPassword()
 
   await page.goto("/signup")
 
-  await fillForm(page, fullName, email, password, password2)
+  await fillForm(page, fullName, username, email, password, password2)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
-  await expect(page.getByText("Passwords do not match")).toBeVisible()
+  await expect(page.getByText("The passwords do not match")).toBeVisible()
 })
 
 test("Sign up with missing full name", async ({ page }) => {
   const fullName = ""
+  const username = `user_${Math.random().toString(36).substring(2)}`
   const email = randomEmail()
   const password = randomPassword()
 
   await page.goto("/signup")
 
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, fullName, username, email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
   await expect(page.getByText("Full Name is required")).toBeVisible()
 })
 
+test("Sign up with missing username", async ({ page }) => {
+  const username = ""
+
+  await page.goto("/signup")
+
+  await fillForm(page, "Test User", username, randomEmail(), randomPassword(), randomPassword())
+  await page.getByRole("button", { name: "Sign Up" }).click()
+
+  await expect(page.getByText("Username is required")).toBeVisible()
+})
+
 test("Sign up with missing email", async ({ page }) => {
-  const fullName = "Test User"
   const email = ""
   const password = randomPassword()
 
   await page.goto("/signup")
 
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, "Test User", "playwright", email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
   await expect(page.getByText("Email is required")).toBeVisible()
 })
 
 test("Sign up with missing password", async ({ page }) => {
-  const fullName = ""
   const email = randomEmail()
   const password = ""
 
   await page.goto("/signup")
 
-  await fillForm(page, fullName, email, password, password)
+  await fillForm(page, "Test User", "playwright", email, password, password)
   await page.getByRole("button", { name: "Sign Up" }).click()
 
   await expect(page.getByText("Password is required")).toBeVisible()

--- a/frontend/tests/utils/user.ts
+++ b/frontend/tests/utils/user.ts
@@ -9,6 +9,7 @@ export async function signUpNewUser(
   await page.goto("/signup")
 
   await page.getByPlaceholder("Full Name").fill(name)
+  await page.getByPlaceholder("Username").fill(email.split("@")[0] || email)
   await page.getByPlaceholder("Email").fill(email)
   await page.getByPlaceholder("Password", { exact: true }).fill(password)
   await page.getByPlaceholder("Confirm Password").fill(password)


### PR DESCRIPTION
This PR introduces username support across the user model and signup flow, and unifies duplicate-user handling to return a 409 Conflict with a simple error body that the UI can render inline.

What changed
- Database and models
  - Add username to User with unique index and non-null, defaulting to email on upgrade.
  - Extend User model and related schemas to include username (UserBase, UserCreate, UserRegister, UserPublic, etc.).
  - Add get_user_by_username in CRUD and expose in API.
  - Alembic migration to add username column and unique index; backfill existing rows and enforce non-null username.
- API behavior
  - conflict_response(field) helper to return 409 with {"error":"conflict","field":"email|username"}.
  - Sign up route now checks both email and username for conflicts before creation and returns the conflict response when found.
  - If a database IntegrityError occurs, map it to the appropriate conflict field (email or username) and return 409 accordingly.
  - Signup now uses username (and email) consistently; email in signup also uses username in user creation and emails, when enabled.
- Frontend and schemas
  - Client and UI schemas/types updated to include username, and required username field added where appropriate.
  - Signup form updated to render Username field and perform inline validation.
  - Error handling updated to surface 409 conflict errors inline (no global toast for conflicts).
- Tests and mocks
  - Updated tests to create and validate users with both email and username.
  - Tests cover duplicate email and duplicate username, asserting 409 with {"error":"conflict","field":...}.
  - Frontend and end-to-end tests updated to ensure inline error display works for duplicates.
- Frontend tweaks
  - Sign up flow now accepts a username, wires up to UI for inline conflict display, and uses username when creating the user.
  - Sign-up tests and mocks adjusted to include username where needed.

Why this solves the issue
- Acceptance criteria alignment:
  - API returns 409 for existing email/username (via conflict_response and mapped IntegrityError handling).
  - Error JSON matches required shape: {"error":"conflict","field":"email|username"}.
  - DB enforces uniqueness on email and username.
  - Signup form shows inline field errors for conflicts.
  - Unit and basic e2e tests cover both duplicate cases.

Notes
- First-time superuser creation now includes a username (derived from the same value as email by default) to ensure consistent data.
- Frontend utils were updated to gracefully handle 409 conflict errors by delegating to inline field errors rather than toasts.
- All changes are cohesive across backend, frontend, tests, and migrations to provide a smooth UX for duplicate signup scenarios.

https://cosine.sh/cosinedemo/full-stack-demo/task/sj61lieyt154
https://cosine.sh/gh/CosineDemoOrg/full-stack-demo/pull/81
Author: James White